### PR TITLE
bug: add parentheses to time step

### DIFF
--- a/scripts/twitter_simulation/group_polarization/twitter_simulation_group_polar.py
+++ b/scripts/twitter_simulation/group_polarization/twitter_simulation_group_polar.py
@@ -133,7 +133,7 @@ async def running(
         print(Back.GREEN + f"DB:{db_file} timestep:{timestep}" + Back.RESET)
         print(Back.YELLOW + "doing test" + Back.RESET)
 
-        if timestep - 1 % 10 == 0:
+        if (timestep - 1) % 10 == 0:
             test_results_list = []
             test_tasks = [
                 agent.perform_test() for agent in agent_graph


### PR DESCRIPTION
The time step for saving the results in group polarization is not correct.

Thanks to Anthony K for finding this bug. 