### PR TITLE
feat: support multi-LLM agents in simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,9 @@ models/
 *.db
 *.sqlite3
 *.sqlite
+
+data/1w
+
+set_vllm
+
+scripts/misinformation_spreading

--- a/README.md
+++ b/README.md
@@ -259,6 +259,16 @@ inference:
   server_url:
     - host: "10.109.1.8"
       ports: [8002, 8003, 8005]  # Input the list of all ports obtained in step 3
+  port_ranges:
+    - range:
+        start: 0
+        end: 50
+      ports: [8002, 8003] # Set the port 8002 and 8003 as the model1
+
+    - range:
+        start: 51
+        end: 10000
+      ports: [8005] # Set the port 8005 as the model1
 ```
 
 Additionally, you can modify other settings related to data and experimental details in the yaml file. For instructions on this part, refer to `scripts\reddit_gpt_example\gpt_example.yaml`.
@@ -287,6 +297,9 @@ python scripts/twitter_simulation/group_polarization/twitter_simulation_group_po
 
 # For One Million Simulation
 python scripts/twitter_simulation_1M_agents/twitter_simulation_1m.py --config_path scripts/twitter_simulation_1M_agents/twitter_1m.yaml
+
+# For hybrid LLMs. Now we can set different LLM-based agents in OASIS. Enjoy it!
+python scripts/twitter_simulation/different_LLM_based_agents/twitter_simulation.py --config_path scripts/twitter_simulation/different_LLM_based_agents/different_LLM_based_agents.yaml
 ```
 
 ## 💡Tips
@@ -306,6 +319,7 @@ The Reddit recommendation system is highly time-sensitive. Currently, one time s
 ## 🚢 More Tutorials
 
 To discover how to create profiles for large-scale users, as well as how to visualize and analyze social simulation data once your experiment concludes, please refer to [More Tutorials](tutorials/tutorial.md) for detailed guidance.
+
 
 ## 📢 News
 

--- a/oasis/inference/inference_thread.py
+++ b/oasis/inference/inference_thread.py
@@ -12,7 +12,9 @@
 # limitations under the License.
 # =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
 import logging
+import time
 from time import sleep
+from typing import Optional
 
 from camel.models import BaseModelBackend, ModelFactory
 from camel.types import ModelPlatformType
@@ -22,20 +24,22 @@ thread_log.setLevel("DEBUG")
 
 
 class SharedMemory:
-    Message_ID = 0
-    Message = None
-    Response = None
-    Busy = False
-    Working = False
-    Done = False
+    """Using dataclass for optimized memory usage and access efficiency"""
+    Message_ID: Optional[str] = None
+    Message: Optional[str] = None
+    Agent_ID: Optional[int] = None
+    Response: Optional[str] = None
+    Done: bool = False
+    Busy: bool = False
+    Working: bool = False
+    last_active: float = time.time()  # Record last active time
 
 
 class InferenceThread:
 
     def __init__(
         self,
-        model_path:
-        str = "/mnt/hwfile/trustai/models/Meta-Llama-3-8B-Instruct",  # noqa
+        model_path: str = "models/Meta-Llama-3-8B-Instruct",  # noqa
         server_url: str = "http://10.140.0.144:8000/v1",
         stop_tokens: list[str] = None,
         model_platform_type: ModelPlatformType = ModelPlatformType.VLLM,
@@ -85,4 +89,4 @@ class InferenceThread:
                 thread_log.info(
                     f"Thread {self.server_url}: {self.count} finished.")
 
-            sleep(0.01)
+            sleep(0.1)

--- a/oasis/social_agent/agent.py
+++ b/oasis/social_agent/agent.py
@@ -161,7 +161,7 @@ class SocialAgent:
                 content = "No response."
 
         else:
-            retry = 5
+            retry = 3 # recomended 3
             exec_functions = []
 
             while retry > 0:
@@ -172,8 +172,8 @@ class SocialAgent:
                         "content": self.system_message.content,
                     }] + openai_messages
                 mes_id = await self.infe_channel.write_to_receive_queue(
-                    openai_messages)
-                mes_id, content = await self.infe_channel.read_from_send_queue(
+                    openai_messages, self.agent_id)
+                mes_id, content, _ = await self.infe_channel.read_from_send_queue(
                     mes_id)
 
                 agent_log.info(
@@ -245,7 +245,7 @@ class SocialAgent:
         agent_log.info(f"Agent {self.agent_id}: {openai_messages}")
 
         message_id = await self.infe_channel.write_to_receive_queue(
-            openai_messages)
+            openai_messages, self.agent_id)
         message_id, content = await self.infe_channel.read_from_send_queue(
             message_id)
         agent_log.info(f"Agent {self.agent_id} receive response: {content}")

--- a/oasis/social_agent/agent_action.py
+++ b/oasis/social_agent/agent_action.py
@@ -55,7 +55,7 @@ class SocialAction:
 
     async def perform_action(self, message: Any, type: str):
         message_id = await self.channel.write_to_receive_queue(
-            (self.agent_id, message, type))
+            (self.agent_id, message, type), self.agent_id)
         response = await self.channel.read_from_send_queue(message_id)
         return response[2]
 

--- a/oasis/social_platform/platform.py
+++ b/oasis/social_platform/platform.py
@@ -117,7 +117,7 @@ class Platform:
 
     async def running(self):
         while True:
-            message_id, data = await self.channel.receive_from()
+            message_id, data, _ = await self.channel.receive_from()
 
             agent_id, message, action = data
             action = ActionType(action)

--- a/oasis/social_platform/recsys.py
+++ b/oasis/social_platform/recsys.py
@@ -460,13 +460,13 @@ def rec_sys_personalized_twh(
                     (271.8 - (current_time - int(post['created_at']))) / 100))
             # Get the audience size of the post, score based on the number of
             # followers
-            try:
-                fans_score.append(
-                    np.log(u_items[post['user_id']] + 1) / np.log(1000))
-            except Exception as e:
-                print(f"Error on fan score calculating: {e}")
-                import pdb
-                pdb.set_trace()
+            # try:
+            #     fans_score.append(
+            #         np.log(u_items[post['user_id']] + 1) / np.log(1000))
+            # except Exception as e:
+            #     print(f"Error on fan score calculating: {e}")
+            #     import pdb
+            #     pdb.set_trace()
 
     date_score_np = np.array(date_score)
     # fan_score [1, 2.x]

--- a/scripts/twitter_simulation/different_LLM_based_agents/different_LLM_based_agents.yaml
+++ b/scripts/twitter_simulation/different_LLM_based_agents/different_LLM_based_agents.yaml
@@ -1,0 +1,39 @@
+---
+data:
+  db_path: data/db/test.db
+  csv_path: data/twitter_dataset/anonymous_topic_200_1h/False_Business_0.csv
+simulation:
+  num_timesteps: 60
+  clock_factor: 60
+  recsys_type: random
+model:
+  num_agents: 111
+  model_random_seed: 42
+  cfgs:
+    - model_type: llama-3
+      num: 111
+      server_url: http://10.140.1.246:8005/v1  # eg, http://10.160.2.154:8000/v1
+      model_path: models/Meta-Llama-3-8B-Instruct
+      stop_tokens: [<|eot_id|>, <|end_of_text|>]
+      temperature: 0.0
+inference:
+  model_type: llama-3
+  model_path: models/Meta-Llama-3-8B-Instruct
+  stop_tokens: [<|eot_id|>, <|end_of_text|>]
+  server_url:
+    - host: 10.140.0.184
+      ports:
+        - 8100
+    - host: 10.140.0.240
+      ports:
+        - 8200
+  port_ranges:
+    - range:
+        start: 0
+        end: 50
+      ports: [8100]
+    - range:
+        start: 51
+        end: 10000
+      ports: [8200]
+

--- a/scripts/twitter_simulation/different_LLM_based_agents/twitter_simulation.py
+++ b/scripts/twitter_simulation/different_LLM_based_agents/twitter_simulation.py
@@ -1,0 +1,180 @@
+# =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import random
+from datetime import datetime
+from typing import Any
+
+import pandas as pd
+from colorama import Back
+from yaml import safe_load
+
+from oasis.clock.clock import Clock
+from oasis.inference.inference_manager import InferencerManager
+from oasis.social_agent.agents_generator import generate_agents_100w
+from oasis.social_platform.channel import Channel
+from oasis.social_platform.platform import Platform
+from oasis.social_platform.typing import ActionType
+
+social_log = logging.getLogger(name='social')
+social_log.setLevel('DEBUG')
+
+file_handler = logging.FileHandler('social.log')
+file_handler.setLevel('DEBUG')
+file_handler.setFormatter(
+    logging.Formatter('%(levelname)s - %(asctime)s - %(name)s - %(message)s'))
+social_log.addHandler(file_handler)
+stream_handler = logging.StreamHandler()
+stream_handler.setLevel('DEBUG')
+stream_handler.setFormatter(
+    logging.Formatter('%(levelname)s - %(asctime)s - %(name)s - %(message)s'))
+social_log.addHandler(stream_handler)
+
+parser = argparse.ArgumentParser(description="Arguments for script.")
+parser.add_argument(
+    "--config_path",
+    type=str,
+    help="Path to the YAML config file.",
+    required=False,
+    default="",
+)
+
+DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
+DEFAULT_DB_PATH = ":memory:"
+DEFAULT_CSV_PATH = os.path.join(DATA_DIR, "user_all_id_time.csv")
+
+
+async def running(
+    db_path: str | None = DEFAULT_DB_PATH,
+    csv_path: str | None = DEFAULT_CSV_PATH,
+    num_timesteps: int = 3,
+    clock_factor: int = 60,
+    recsys_type: str = "twitter",
+    model_configs: dict[str, Any] | None = None,
+    inference_configs: dict[str, Any] | None = None,
+) -> None:
+    db_path = DEFAULT_DB_PATH if db_path is None else db_path
+    csv_path = DEFAULT_CSV_PATH if csv_path is None else csv_path
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    if recsys_type == "reddit":
+        start_time = datetime.now()
+    else:
+        start_time = 0
+    social_log.info(f"Start time: {start_time}")
+    clock = Clock(k=clock_factor)
+    twitter_channel = Channel()
+    infra = Platform(db_path,
+                     twitter_channel,
+                     clock,
+                     start_time,
+                     recsys_type=recsys_type,
+                     refresh_rec_post_count=2,
+                     max_rec_post_len=2,
+                     following_post_count=3)
+    inference_channel = Channel()
+    infere = InferencerManager(
+        inference_channel,
+        **inference_configs,
+    )
+    twitter_task = asyncio.create_task(infra.running())
+    inference_task = asyncio.create_task(infere.run())
+
+    try:
+        all_topic_df = pd.read_csv("data/label_clean_v7.csv")
+        if "False" in csv_path or "True" in csv_path:
+            if "-" not in csv_path:
+                topic_name = csv_path.split("/")[-1].split(".")[0]
+            else:
+                topic_name = csv_path.split("/")[-1].split(".")[0].split(
+                    "-")[0]
+            source_post_time = all_topic_df[
+                all_topic_df["topic_name"] ==
+                topic_name]["start_time"].item().split(" ")[1]
+            start_hour = int(source_post_time.split(":")[0]) + float(
+                int(source_post_time.split(":")[1]) / 60)
+    except Exception:
+        print("No real-world data, let start_hour be 13")
+        start_hour = 13
+
+    model_configs = model_configs or {}
+    agent_graph = await generate_agents_100w(
+        agent_info_path=csv_path,
+        twitter_channel=twitter_channel,
+        inference_channel=inference_channel,
+        start_time=start_time,
+        recsys_type=recsys_type,
+        twitter=infra,
+        **model_configs,
+    )
+    # agent_graph.visualize("initial_social_graph.png")
+
+    for timestep in range(1, num_timesteps + 1):
+        os.environ["SANDBOX_TIME"] = str(timestep * 3)
+        social_log.info(f"timestep:{timestep}")
+        db_file = db_path.split("/")[-1]
+        print(Back.GREEN + f"DB:{db_file} timestep:{timestep}" + Back.RESET)
+        print(Back.YELLOW + "doing test" + Back.RESET)
+        await infra.update_rec_table()
+        # 0.05 * timestep here means 3 minutes / timestep
+        simulation_time_hour = start_hour + 0.05 * timestep
+        tasks = []
+        for agent in agent_graph:
+            if agent.user_info.is_controllable is False:
+                agent_ac_prob = random.random()
+                threshold = agent.user_info.profile['other_info'][
+                    'active_threshold'][int(simulation_time_hour % 24)]
+                if agent.agent_id < 197:
+                    if agent_ac_prob < 0.1:
+                        tasks.append(agent.perform_action_by_llm())
+                else:
+                    if agent_ac_prob < threshold:
+                        tasks.append(agent.perform_action_by_llm())
+            else:
+                await agent.perform_action_by_hci()
+
+        await asyncio.gather(*tasks)
+        # agent_graph.visualize(f"timestep_{timestep}_social_graph.png")
+
+    await twitter_channel.write_to_receive_queue((None, None, ActionType.EXIT),
+                                                 0)
+    await infere.stop()
+    await twitter_task, inference_task
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    os.environ["SANDBOX_TIME"] = str(0)
+    if os.path.exists(args.config_path):
+        with open(args.config_path, "r") as f:
+            cfg = safe_load(f)
+        data_params = cfg.get("data")
+        simulation_params = cfg.get("simulation")
+        model_configs = cfg.get("model")
+        inference_configs = cfg.get("inference")
+
+        asyncio.run(
+            running(**data_params,
+                    **simulation_params,
+                    model_configs=model_configs,
+                    inference_configs=inference_configs))
+    else:
+        asyncio.run(running())
+    social_log.info("Simulation finished.")

--- a/scripts/twitter_simulation/group_polarization/group_polarization.yaml
+++ b/scripts/twitter_simulation/group_polarization/group_polarization.yaml
@@ -13,12 +13,12 @@ model:
     - model_type: llama-3
       num: 196
       server_url: http://10.140.1.129:8002/v1  # eg, http://10.160.2.154:8000/v1
-      model_path: /mnt/hwfile/trustai/models/Meta-Llama-3-8B-Instruct
+      model_path: models/Meta-Llama-3-8B-Instruct
       stop_tokens: [<|eot_id|>, <|end_of_text|>]
       temperature: 0.0
 inference:
   model_type: llama-3
-  model_path: /mnt/hwfile/trustai/models/Meta-Llama-3-8B-Instruct
+  model_path: models/Meta-Llama-3-8B-Instruct
   stop_tokens: [<|eot_id|>, <|end_of_text|>]
   server_url:
     - host: 10.140.1.129

--- a/test/agent/test_agent_generator.py
+++ b/test/agent/test_agent_generator.py
@@ -55,7 +55,7 @@ async def running():
             },
         ],
     )
-    await twitter_channel.write_to_receive_queue((None, None, "exit"))
+    await twitter_channel.write_to_receive_queue((None, None, "exit"), 0)
     await task
     assert agent_graph.get_num_nodes() == 111
 
@@ -85,6 +85,6 @@ async def test_generate_controllable(monkeypatch):
         agent_graph,
         agent_user_id_mapping,
     )
-    await twitter_channel.write_to_receive_queue((None, None, "exit"))
+    await twitter_channel.write_to_receive_queue((None, None, "exit"), 0)
     await task
     assert agent_graph.get_num_nodes() == 27

--- a/test/agent/test_multi_agent_signup_create.py
+++ b/test/agent/test_multi_agent_signup_create.py
@@ -75,7 +75,7 @@ async def test_agents_posting(setup_platform):
             await agent.env.action.create_post(f"hello from {agent.agent_id}")
             await asyncio.sleep(random.uniform(0, 0.1))
 
-    await channel.write_to_receive_queue((None, None, "exit"))
+    await channel.write_to_receive_queue((None, None, "exit"), 0)
     await task
 
     # Verify if data was correctly inserted into the database

--- a/test/agent/test_twitter_user_agent_all_actions.py
+++ b/test/agent/test_twitter_user_agent_all_actions.py
@@ -75,7 +75,7 @@ async def test_agents_actions(setup_twitter):
             assert return_message["success"] is True
 
     await channel.write_to_receive_queue(
-        (None, None, ActionType.UPDATE_REC_TABLE))
+        (None, None, ActionType.UPDATE_REC_TABLE), 0)
 
     # Look at the posts returned by the recommendation system
     action_agent = agents[2]
@@ -169,5 +169,5 @@ async def test_agents_actions(setup_twitter):
     assert return_message["success"] is True
     await asyncio.sleep(random.uniform(0, 0.1))
 
-    await channel.write_to_receive_queue((None, None, ActionType.EXIT))
+    await channel.write_to_receive_queue((None, None, ActionType.EXIT), 0)
     await task

--- a/test/inference/test_inference_manager.py
+++ b/test/inference/test_inference_manager.py
@@ -1,0 +1,178 @@
+# =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+
+# Import the classes to test
+from oasis.inference.inference_manager import (InferencerManager, PortManager)
+
+
+# Mock InferenceThread since we don't have the actual implementation
+class MockInferenceThread:
+
+    def __init__(self, model_path, server_url, stop_tokens, model_type,
+                 temperature, shared_memory):
+        self.model_path = model_path
+        self.server_url = server_url
+        self.stop_tokens = stop_tokens
+        self.model_type = model_type
+        self.temperature = temperature
+        self.shared_memory = shared_memory
+        self.alive = True
+
+    def run(self):
+        pass
+
+
+class MockChannel:
+
+    def __init__(self):
+        self.receive_queue = asyncio.Queue()
+        self.send_queue = asyncio.Queue()
+
+    async def receive_from(self):
+        return await self.receive_queue.get()
+
+    async def send_to(self, message):
+        await self.send_queue.put(message)
+
+
+# Test configuration
+TEST_SERVER_URL = [{"host": "localhost", "ports": [8000, 8001]}]
+TEST_MODEL_TYPE = "test_model"
+TEST_MODEL_PATH = "/path/to/model"
+TEST_STOP_TOKENS = ["<|end|>"]
+
+
+class TestInferencerManager:
+
+    @pytest.fixture
+    def manager(self):
+        # Setup mock channel
+        channel = MockChannel()
+
+        # Setup port ranges
+        mock_port_ranges = [{
+            'range': {
+                'start': 0,
+                'end': 50
+            },
+            'ports': [8000]
+        }, {
+            'range': {
+                'start': 51,
+                'end': 100000
+            },
+            'ports': [8000]
+        }]
+
+        with patch('oasis.inference.inference_thread.InferenceThread',
+                   MockInferenceThread):
+            # Create InferencerManager instance
+            manager = InferencerManager(channel=channel,
+                                        model_type=TEST_MODEL_TYPE,
+                                        model_path=TEST_MODEL_PATH,
+                                        stop_tokens=TEST_STOP_TOKENS,
+                                        server_url=TEST_SERVER_URL,
+                                        port_ranges=mock_port_ranges,
+                                        timeout=5)
+
+            yield manager
+
+            # Cleanup
+            asyncio.run(manager.stop())
+
+    @pytest.mark.asyncio
+    async def test_initialization(self, manager):
+        assert len(manager.threads
+                   ) == 2  # Should have two threads for ports 8000 and 8001
+        assert manager.timeout == 5
+        assert isinstance(manager.port_manager, PortManager)
+        assert manager.metrics['total_requests'] == 0
+
+    @pytest.mark.asyncio
+    async def test_handle_new_request(self, manager):
+        # Prepare test message
+        test_message = ("msg_id_1", "test message", "1")
+        await manager.channel.receive_queue.put(test_message)
+
+        # Handle the request
+        await manager._handle_new_request()
+
+        # Verify thread assignment
+        assigned_thread = None
+        assigned_port = None
+        for port, thread in manager.threads.items():
+            if thread.shared_memory.Message_ID == "msg_id_1":
+                assigned_thread = thread
+                assigned_port = port
+                break
+
+        assert assigned_thread is not None
+        assert assigned_port in [8000, 8001]
+        assert manager.metrics['total_requests'] == 1
+
+    @pytest.mark.asyncio
+    async def test_process_completed_tasks(self, manager):
+        # Simulate completed task
+        test_port = 8000
+        test_thread = manager.threads[test_port]
+        test_thread.shared_memory.Message_ID = "msg_id_1"
+        test_thread.shared_memory.Response = "test response"
+        test_thread.shared_memory.Agent_ID = 1
+        test_thread.shared_memory.Done = True
+
+        # Process completed tasks
+        await manager._process_completed_tasks()
+
+        # Verify response was sent
+        response = await manager.channel.send_queue.get()
+        assert response == ("msg_id_1", "test response", 1)
+        assert manager.metrics['successful_requests'] == 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_handling(self, manager):
+        # Simulate timeout scenario
+        test_port = 8000
+        test_thread = manager.threads[test_port]
+        test_thread.shared_memory.Busy = True
+        test_thread.shared_memory.last_active = time.time(
+        ) - manager.timeout - 1
+
+        # Try to find available thread
+        thread, port = await manager._find_available_thread(agent_id=1)
+
+        # Should get the timed-out thread
+        assert thread is test_thread
+        assert port == test_port
+        assert not thread.shared_memory.Busy
+
+    @pytest.mark.asyncio
+    async def test_metrics(self, manager):
+        # Simulate successful request
+        test_message = ("msg_id_1", "test message", "1")
+        await manager.channel.receive_queue.put(test_message)
+        await manager._handle_new_request()
+
+        # Verify metrics
+        metrics = manager.get_metrics()
+        assert metrics['total_requests'] > 0
+        assert isinstance(metrics['average_processing_time'], float)
+
+
+if __name__ == '__main__':
+    pytest.main(['-v'])

--- a/test/inference/test_inference_system/channel.py
+++ b/test/inference/test_inference_system/channel.py
@@ -11,12 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+# channel.py
 import asyncio
 import uuid
 
-
 class AsyncSafeDict:
-
     def __init__(self):
         self.dict = {}
         self.lock = asyncio.Lock()
@@ -37,12 +36,9 @@ class AsyncSafeDict:
         async with self.lock:
             return list(self.dict.keys())
 
-
 class Channel:
-
     def __init__(self):
         self.receive_queue = asyncio.Queue()  # Used to store received messages
-        # Using an asynchronous safe dictionary to store messages to be sent
         self.send_dict = AsyncSafeDict()
 
     async def receive_from(self):
@@ -67,5 +63,4 @@ class Channel:
                 if message:
                     return message  # Return the found message
             # Temporarily suspend to avoid tight looping
-            await asyncio.sleep(
-                0.1)  # set a large one to reduce the workload of cpu
+            await asyncio.sleep(0.1)  # Adjust as needed

--- a/test/inference/test_inference_system/inference_manager.py
+++ b/test/inference/test_inference_system/inference_manager.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
-
+# inference_manager.py
 import asyncio
 import logging
 import sys
@@ -21,8 +21,8 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
-# Assuming InferenceThread and SharedMemory are defined elsewhere
-from oasis.inference.inference_thread import InferenceThread
+from channel import Channel
+from mock_model_backend import MockModelBackend  # Import the mock backend
 
 # Setup logging
 logging.basicConfig(
@@ -30,7 +30,7 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[logging.FileHandler('inference.log'),
               logging.StreamHandler()])
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("InferenceManager")
 
 
 @dataclass
@@ -50,18 +50,14 @@ class SharedMemory:
 class PortManager:
     """Class to manage port allocations"""
 
-    def __init__(self, port_ranges: Dict[Tuple[int, int], range]):
+    def __init__(self, port_ranges: Dict[Tuple[int, int], List[int]]):
         self.port_ranges = port_ranges
         self.agent_to_ports: Dict[int, List[int]] = defaultdict(list)
         self._initialize_mappings()
 
     def _initialize_mappings(self):
         """Initialize agent_id to port mappings"""
-        port_ranges_dict = {
-            (entry["range"]["start"], entry["range"]["end"]): entry["ports"]
-            for entry in self.port_ranges
-        }
-        for (start_id, end_id), ports in port_ranges_dict.items():
+        for (start_id, end_id), ports in self.port_ranges.items():
             for agent_id in range(start_id, end_id + 1):
                 self.agent_to_ports[agent_id].extend(ports)
 
@@ -70,35 +66,58 @@ class PortManager:
         return self.agent_to_ports.get(agent_id, [])
 
 
-from os import cpu_count
-
-from oasis.inference.inference_thread import SharedMemory
-
-inference_log = logging.getLogger(name="inference")
-inference_log.setLevel("DEBUG")
-
-file_handler = logging.FileHandler("inference.log")
-file_handler.setLevel("DEBUG")
-file_handler.setFormatter(
-    logging.Formatter("%(levelname)s - %(asctime)s - %(name)s - %(message)s"))
-inference_log.addHandler(file_handler)
-
-
-class InferencerManager:
+class InferenceThread:
 
     def __init__(
         self,
-        channel,
-        model_type: str,
-        model_path: str,
-        stop_tokens: List[str],
-        server_url: List[Dict],
-        port_ranges: Optional[Dict[Tuple[int, int], List[int]]] = None,
-        timeout: int = 300,  # Timeout in seconds
-        threads_per_port: int = 20,
-        max_workers: int = 80,
+        model_path: str = "/path/to/mock/model",
+        server_url: str = "http://localhost:8000/v1",
+        stop_tokens: list = None,
+        model_type: str = "mock-model",
+        temperature: float = 0.5,
+        shared_memory: SharedMemory = None,
     ):
+        self.alive = True
         self.count = 0
+        self.server_url = server_url
+        self.model_type = model_type
+        self.model_backend = MockModelBackend()  # Use the mock backend
+        if shared_memory is None:
+            self.shared_memory = SharedMemory()
+        else:
+            self.shared_memory = shared_memory
+
+    async def run(self):
+        while self.alive:
+            if self.shared_memory.Busy and not self.shared_memory.Working:
+                self.shared_memory.Working = True
+                try:
+                    response = await self.model_backend.run(
+                        self.shared_memory.Message)
+                    self.shared_memory.Response = response.choices[
+                        0].message.content
+                except Exception as e:
+                    print("Receive Response Exception:", str(e))
+                    self.shared_memory.Response = "No response."
+                self.shared_memory.Done = True
+                self.count += 1
+                logger.info(
+                    f"Thread {self.server_url}: {self.count} finished.")
+            await asyncio.sleep(0.1)
+
+
+class InferenceManager:
+
+    def __init__(
+            self,
+            channel: Channel,
+            model_type: str,
+            model_path: str,
+            stop_tokens: List[str],
+            server_url: List[Dict],
+            port_ranges: Optional[Dict[Tuple[int, int], List[int]]] = None,
+            timeout: int = 300  # Timeout in seconds
+    ):
         self.channel = channel
         self.threads: Dict[int, InferenceThread] = {}
         self.lock = asyncio.Lock(
@@ -122,7 +141,7 @@ class InferencerManager:
 
         # Initialize threads
         self._initialize_threads(server_url, model_type, model_path,
-                                 stop_tokens, max_workers, threads_per_port)
+                                 stop_tokens)
 
         # Performance metrics
         self.metrics = {
@@ -136,69 +155,26 @@ class InferencerManager:
         self.executor = ThreadPoolExecutor(max_workers=len(self.threads))
 
     def _initialize_threads(self, server_url, model_type, model_path,
-                            stop_tokens, max_workers, threads_per_port):
-        # """Initialize inference threads"""
-        # for url_config in server_url:
-        #     host = url_config["host"]
-        #     for port in url_config["ports"]:
-        #         try:
-        #             _url = f"http://{host}:{port}/v1"
-        #             shared_memory = SharedMemory()
-        #             thread = InferenceThread(
-        #                 model_path=model_path,
-        #                 server_url=_url,
-        #                 stop_tokens=stop_tokens,
-        #                 model_type=model_type,
-        #                 temperature=0.0,
-        #                 shared_memory=shared_memory,
-        #             )
-        #             self.threads[port] = thread
-        #         except Exception as e:
-        #             logger.error(f"Failed to initialize thread for port {port}: {e}")
-
-        # Check if max_workers is set to a reasonable value
-        if max_workers < 1:
-            inference_log.error(
-                "Max workers must be at least 1. Setting to 1.")
-            max_workers = 1
-        # For IO bound tasks, max_workers should be set to a higher value
-        # between 5 and 20 times the number of CPUs
-        elif max_workers > cpu_count() * 20:
-            inference_log.warning(
-                f"Max workers is higher than recommended value. Setting to "
-                f"{cpu_count() * 20}.")
-            max_workers = cpu_count() * 20
-
-        # Check if threads_per_port is set to a reasonable value
-        total_ports = 0
-        for url in server_url:
-            total_ports += len(url["ports"])
-        if total_ports * threads_per_port > max_workers:
-            threads_per_port = max(max_workers // total_ports, 1)
-            inference_log.warning(
-                f"Total threads exceeds max workers. Setting threads per port "
-                f"to {threads_per_port}.")
-        if threads_per_port < 1:
-            inference_log.error(
-                "Threads per port must be at least 1. Setting to 1.")
-            threads_per_port = 1
-
-        for url in server_url:
-            host = url["host"]
-            for port in url["ports"]:
-                _url = f"http://{host}:{port}/v1"
-                thread = [
-                    InferenceThread(
+                            stop_tokens):
+        """Initialize inference threads"""
+        for url_config in server_url:
+            host = url_config["host"]
+            for port in url_config["ports"]:
+                try:
+                    _url = f"http://{host}:{port}/v1"
+                    shared_memory = SharedMemory()
+                    thread = InferenceThread(
                         model_path=model_path,
                         server_url=_url,
                         stop_tokens=stop_tokens,
                         model_type=model_type,
                         temperature=0.0,
-                        shared_memory=SharedMemory(),
-                    ) for _ in range(threads_per_port)
-                ]
-                for t in thread:
-                    self.threads[port] = t
+                        shared_memory=shared_memory,
+                    )
+                    self.threads[port] = thread
+                except Exception as e:
+                    logger.error(
+                        f"Failed to initialize thread for port {port}: {e}")
 
     async def _find_available_thread(
             self,
@@ -214,8 +190,8 @@ class InferencerManager:
 
             async with self.lock:
                 if (not thread.shared_memory.Busy
-                        or (current_time - thread.shared_memory.last_active)
-                        > self.timeout):
+                        or (current_time - thread.shared_memory.last_active
+                            > self.timeout)):
                     if thread.shared_memory.Busy:
                         thread.shared_memory = SharedMemory()
                         logger.warning(
@@ -307,10 +283,8 @@ class InferencerManager:
                              message: Tuple[str, str, str]):
         """Run inference in a separate thread and update shared_memory"""
         try:
-            await asyncio.get_event_loop().run_in_executor(
-                self.executor,
-                thread.run,  # Assuming `run` is a blocking method
-            )
+            # Run the thread's run method
+            await thread.run()
             async with self.lock:
                 thread.shared_memory.Done = True
         except Exception as e:
@@ -326,8 +300,8 @@ class InferencerManager:
         """Main run loop"""
         # Start all inference threads
         for port, thread in self.threads.items():
-            # Start each thread in the ThreadPoolExecutor
-            asyncio.get_event_loop().run_in_executor(self.executor, thread.run)
+            # Start each thread's run method as a task
+            asyncio.create_task(thread.run())
 
         # Create background tasks
         process_tasks_task = asyncio.create_task(

--- a/test/inference/test_inference_system/mock_model_backend.py
+++ b/test/inference/test_inference_system/mock_model_backend.py
@@ -1,0 +1,44 @@
+# =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+# mock_model_backend.py
+import asyncio
+import random
+
+
+class MockModelBackend:
+
+    async def run(self, message):
+        # Simulate processing time between 0.1 to 0.5 seconds
+        await asyncio.sleep(random.uniform(0.1, 0.5))
+        #await asyncio.sleep(0.5)
+        # Simulate a response
+        return MockResponse(f"Processed: {message}")
+
+
+class MockResponse:
+
+    def __init__(self, content):
+        self.choices = [MockChoice(content)]
+
+
+class MockChoice:
+
+    def __init__(self, content):
+        self.message = MockMessage(content)
+
+
+class MockMessage:
+
+    def __init__(self, content):
+        self.content = content

--- a/test/inference/test_inference_system/readme.md
+++ b/test/inference/test_inference_system/readme.md
@@ -1,0 +1,66 @@
+# Inference Manager Test Project
+
+## Overview
+
+The **Inference Manager Test Project** simulates and evaluates the inference management system in OASIS, which is designed to handle a large number of Large Language Model (LLM) requests efficiently. This project integrates key components to test the system’s ability to manage and process massive concurrent requests.
+
+## Project Structure
+
+```
+inference-manager-test/
+│
+├── channel.py
+├── mock_model_backend.py
+├── inference_manager.py
+├── test_inference_system.py
+└── README.md
+```
+
+- **channel.py**: Manages communication between requests and responses.
+- **mock_model_backend.py**: Simulates the behavior of an actual model backend.
+- **inference_manager.py**: Handles the orchestration of inference threads and request processing.
+- **test_inference_system.py**: Sends test requests and collects responses.
+- **README.md**: Project documentation.
+
+## Components
+
+1. Channel
+
+Handles the flow of messages between incoming requests and outgoing responses using asynchronous queues and dictionaries.
+
+2. Mock Model Backend
+
+Simulates processing of inference requests by introducing delays and returning mock responses without needing a real LLM model.
+
+3. InferenceThread
+
+Represents a worker that processes individual inference requests using the mock backend.
+
+4. InferenceManager
+
+Coordinates multiple InferenceThread instances, assigns incoming requests to available threads, and tracks performance metrics.
+
+5. Test Harness
+
+A script that sends a large number of test requests to the system and collects the responses to evaluate performance.
+
+## Setup Instructions
+
+### Prerequisites
+
+The same with OASIS
+
+### Run
+
+```
+# Modify the num_requests variable in ßtest_inference_system.py.
+python test_inference_system.py
+```
+
+### what happens
+
+- **Initialization**: Sets up the communication channel and inference manager with mock threads.
+- **Sending Requests**: Sends a predefined number of test messages to simulate LLM requests.
+- **Processing**: InferenceManager assigns requests to available threads for processing.
+- **Collecting Responses**: Gathers and displays responses from the processed requests.
+- **Metrics**: Displays performance metrics like total requests, successful and failed requests, and average processing time.

--- a/test/inference/test_inference_system/test_inference_system.py
+++ b/test/inference/test_inference_system/test_inference_system.py
@@ -1,0 +1,92 @@
+# =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+# test_inference_system.py
+import asyncio
+import time
+
+from channel import Channel
+from inference_manager import InferenceManager
+
+
+async def main():
+    start_time = time.time()
+    # Initialize the channel
+    channel = Channel()
+
+    # Define server URLs and port ranges
+    server_url = [
+        {
+            "host": "localhost",
+            "ports": [8000, 8001, 8002, 8003, 8004, 8005, 8006, 8007]
+        },  # Example ports
+    ]
+    port_ranges = {
+        (0, 50): [8000, 8001, 8002,
+                  8003],  # Agents 0-100 can use ports 8000-8002
+        (49, 100): [8004, 8005, 8006,
+                    8007],  # Agents 0-100 can use ports 8000-8002
+    }
+
+    # Initialize the InferenceManager
+    manager = InferenceManager(channel=channel,
+                               model_type="mock-model",
+                               model_path="/path/to/mock/model",
+                               stop_tokens=["\n"],
+                               server_url=server_url,
+                               port_ranges=port_ranges,
+                               timeout=300)
+
+    # Start the InferenceManager
+    manager_task = asyncio.create_task(manager.run())
+
+    # Number of test requests
+    num_requests = 100  # Adjust as needed for "massive" testing
+
+    # Function to send requests
+    async def send_requests():
+        for i in range(num_requests):
+            action_info = f"Test message {i}"
+            agent_id = i % 100  # Example agent IDs
+            message_id = await channel.write_to_receive_queue(
+                action_info, agent_id)
+            print(f"Sent request {i} with message_id {message_id}")
+            await asyncio.sleep(0.01)  # Slight delay between sends
+
+    # Function to collect responses
+    async def collect_responses():
+        collected = 0
+        while collected < num_requests:
+            # For testing, we'll check all message IDs
+            keys = await channel.send_dict.keys()
+            for message_id in keys:
+                message = await channel.read_from_send_queue(message_id)
+                print(f"Received response for {message_id}: {message[1]}")
+                collected += 1
+            await asyncio.sleep(0.1)
+        print("All responses collected.")
+        # Stop the manager after collecting all responses
+        await manager.stop()
+
+    # Start sending requests and collecting responses concurrently
+    await asyncio.gather(send_requests(), collect_responses(), manager_task)
+
+    # Print final metrics
+    metrics = manager.get_metrics()
+    end_time = time.time()
+    print("Final Metrics:", metrics)
+    print(start_time - end_time)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/test/infra/database/test_comment.py
+++ b/test/infra/database/test_comment.py
@@ -32,30 +32,30 @@ class MockChannel:
     async def receive_from(self):
         if self.call_count == 0:
             self.call_count += 1
-            return ("id_", (1, "Test post", "create_post"))
+            return ("id_", (1, "Test post", "create_post"), 0)
         if self.call_count == 1:
             self.call_count += 1
-            return ("id_", (1, (1, "Test Comment"), "create_comment"))
+            return ("id_", (1, (1, "Test Comment"), "create_comment"), 0)
         if self.call_count == 2:
             self.call_count += 1
-            return ("id_", (1, 1, "like_comment"))
+            return ("id_", (1, 1, "like_comment"), 0)
         if self.call_count == 3:
             self.call_count += 1
-            return ("id_", (2, 1, "like_comment"))
+            return ("id_", (2, 1, "like_comment"), 0)
         if self.call_count == 4:
             self.call_count += 1
-            return ("id_", (2, 1, "unlike_comment"))
+            return ("id_", (2, 1, "unlike_comment"), 0)
         if self.call_count == 5:
             self.call_count += 1
-            return ("id_", (1, 1, "dislike_comment"))
+            return ("id_", (1, 1, "dislike_comment"), 0)
         if self.call_count == 6:
             self.call_count += 1
-            return ("id_", (2, 1, "dislike_comment"))
+            return ("id_", (2, 1, "dislike_comment"), 0)
         if self.call_count == 7:
             self.call_count += 1
-            return ("id_", (2, 1, "undo_dislike_comment"))
+            return ("id_", (2, 1, "undo_dislike_comment"), 0)
         else:
-            return ("id_", (None, None, "exit"))
+            return ("id_", (None, None, "exit"), 0)
 
     async def send_to(self, message):
         # Store the message for subsequent assertions.

--- a/test/infra/database/test_comment_self_rating.py
+++ b/test/infra/database/test_comment_self_rating.py
@@ -33,26 +33,26 @@ class MockChannel:
         # The first call returns the command to create a post
         if self.call_count == 0:
             self.call_count += 1
-            return ("id_", (1, "Test post", "create_post"))
+            return ("id_", (1, "Test post", "create_post"), 0)
         # The second call returns the command to create a comment.
         if self.call_count == 1:
             self.call_count += 1
-            return ("id_", (1, (1, "Test Comment"), "create_comment"))
+            return ("id_", (1, (1, "Test Comment"), "create_comment"), 0)
         # The third call returns the command to like a comment.
         if self.call_count == 2:
             self.call_count += 1
-            return ("id_", (1, 1, "like_comment"))
+            return ("id_", (1, 1, "like_comment"), 0)
         if self.call_count == 3:
             self.call_count += 1
-            return ("id_", (2, 1, "like_comment"))
+            return ("id_", (2, 1, "like_comment"), 0)
         if self.call_count == 4:
             self.call_count += 1
-            return ("id_", (1, 1, "dislike_comment"))
+            return ("id_", (1, 1, "dislike_comment"), 0)
         if self.call_count == 5:
             self.call_count += 1
-            return ("id_", (2, 1, "dislike_comment"))
+            return ("id_", (2, 1, "dislike_comment"), 0)
         else:
-            return ("id_", (None, None, "exit"))
+            return ("id_", (None, None, "exit"), 0)
 
     async def send_to(self, message):
         # Store the message for subsequent assertions.

--- a/test/infra/database/test_do_nothing.py
+++ b/test/infra/database/test_do_nothing.py
@@ -33,9 +33,9 @@ class MockChannel:
     async def receive_from(self):
         if self.call_count == 0:
             self.call_count += 1
-            return ("id_", (1, None, ActionType.DO_NOTHING))
+            return ("id_", (1, None, ActionType.DO_NOTHING), 0)
         else:
-            return ("id_", (None, None, ActionType.EXIT))
+            return ("id_", (None, None, ActionType.EXIT), 0)
 
     async def send_to(self, message):
         self.messages.append(message)

--- a/test/infra/database/test_multi_create_post.py
+++ b/test/infra/database/test_multi_create_post.py
@@ -39,9 +39,9 @@ class MockChannel:
         if self.action_index < len(self.user_actions):
             action = self.user_actions[self.action_index]
             self.action_index += 1
-            return ("id_", action)
+            return ("id_", action, 0)
         else:
-            return ("id_", (None, None, "exit"))
+            return ("id_", (None, None, "exit"), 0)
 
     async def send_to(self, message):
         self.messages.append(message)

--- a/test/infra/database/test_post.py
+++ b/test/infra/database/test_post.py
@@ -33,59 +33,59 @@ class MockChannel:
         # The first call returns the command to create a post
         if self.call_count == 0:
             self.call_count += 1
-            return ("id_", (1, "This is a test post", "create_post"))
+            return ("id_", (1, "This is a test post", "create_post"), 0)
         # The second call returns the command for a like operation
         elif self.call_count == 1:
             self.call_count += 1
-            return ("id_", (1, 1, "like_post"))
+            return ("id_", (1, 1, "like_post"), 0)
         elif self.call_count == 2:
             self.call_count += 1
-            return ("id_", (2, 1, "like_post"))
+            return ("id_", (2, 1, "like_post"), 0)
         elif self.call_count == 3:
             self.call_count += 1
-            return ("id_", (2, 1, "unlike_post"))
+            return ("id_", (2, 1, "unlike_post"), 0)
         elif self.call_count == 4:
             self.call_count += 1
-            return ("id_", (1, 1, "dislike_post"))
+            return ("id_", (1, 1, "dislike_post"), 0)
         elif self.call_count == 5:
             self.call_count += 1
-            return ("id_", (2, 1, "dislike_post"))
+            return ("id_", (2, 1, "dislike_post"), 0)
         elif self.call_count == 6:
             self.call_count += 1
-            return ("id_", (2, 1, "undo_dislike_post"))
+            return ("id_", (2, 1, "undo_dislike_post"), 0)
         # The call returns the command for a repost operation
         elif self.call_count == 7:
             self.call_count += 1
-            return ("id_", (2, 1, "repost"))
+            return ("id_", (2, 1, "repost"), 0)
         elif self.call_count == 8:
             self.call_count += 1
-            return ("id_", (2, 2, "like_post"))
+            return ("id_", (2, 2, "like_post"), 0)
         elif self.call_count == 9:
             self.call_count += 1
-            return ("id_", (2, 1, "repost"))
+            return ("id_", (2, 1, "repost"), 0)
         elif self.call_count == 10:
             self.call_count += 1
-            return ("id_", (2, 3, "repost"))
+            return ("id_", (2, 3, "repost"), 0)
         elif self.call_count == 11:
             self.call_count += 1
-            return ("id_", (3, 2, "repost"))
+            return ("id_", (3, 2, "repost"), 0)
         elif self.call_count == 12:
             self.call_count += 1
-            return ("id_", (1, (1, 'I like the post.'), "quote_post"))
+            return ("id_", (1, (1, 'I like the post.'), "quote_post"), 0)
         elif self.call_count == 13:
             self.call_count += 1
             return ("id_", (2, (2, 'I quote to the reposted post.'),
-                            "quote_post"))
+                            "quote_post"), 0)
         elif self.call_count == 14:
             self.call_count += 1
-            return ("id_", (1, 4, "repost"))
+            return ("id_", (1, 4, "repost"), 0)
         elif self.call_count == 15:
             self.call_count += 1
             return ("id_", (2, (4, 'I quote to the quoted post.'),
-                            "quote_post"))
+                            "quote_post"), 0)
         # Returns the exit command
         else:
-            return ("id_", (None, None, "exit"))
+            return ("id_", (None, None, "exit"), 0)
 
     async def send_to(self, message):
         # Store the message for subsequent assertions

--- a/test/infra/database/test_post_self_rating.py
+++ b/test/infra/database/test_post_self_rating.py
@@ -32,21 +32,21 @@ class MockChannel:
     async def receive_from(self):
         if self.call_count == 0:
             self.call_count += 1
-            return ("id_", (1, "This is a test post", "create_post"))
+            return ("id_", (1, "This is a test post", "create_post"), 0)
         elif self.call_count == 1:
             self.call_count += 1
-            return ("id_", (1, 1, "like_post"))
+            return ("id_", (1, 1, "like_post"), 0)
         elif self.call_count == 2:
             self.call_count += 1
-            return ("id_", (2, 1, "like_post"))
+            return ("id_", (2, 1, "like_post"), 0)
         elif self.call_count == 3:
             self.call_count += 1
-            return ("id_", (1, 1, "dislike_post"))
+            return ("id_", (1, 1, "dislike_post"), 0)
         elif self.call_count == 4:
             self.call_count += 1
-            return ("id_", (2, 1, "dislike_post"))
+            return ("id_", (2, 1, "dislike_post"), 0)
         else:
-            return ("id_", (None, None, "exit"))
+            return ("id_", (None, None, "exit"), 0)
 
     async def send_to(self, message):
         self.messages.append(message)

--- a/test/infra/database/test_product.py
+++ b/test/infra/database/test_product.py
@@ -34,21 +34,21 @@ class MockChannel:
         if self.call_count == 0:
             self.call_count += 1
             return ("id_", (1, ('apple', 1),
-                            ActionType.PURCHASE_PRODUCT.value))
+                            ActionType.PURCHASE_PRODUCT.value), 0)
         if self.call_count == 1:
             self.call_count += 1
             return ("id_", (2, ('apple', 2),
-                            ActionType.PURCHASE_PRODUCT.value))
+                            ActionType.PURCHASE_PRODUCT.value), 0)
         if self.call_count == 2:
             self.call_count += 1
             return ("id_", (2, ('banana', 1),
-                            ActionType.PURCHASE_PRODUCT.value))
+                            ActionType.PURCHASE_PRODUCT.value), 0)
         if self.call_count == 3:
             self.call_count += 1
             return ("id_", (2, ('orange', 1),
-                            ActionType.PURCHASE_PRODUCT.value))
+                            ActionType.PURCHASE_PRODUCT.value), 0)
         else:
-            return ("id_", (None, None, "exit"))
+            return ("id_", (None, None, "exit"), 0)
 
     async def send_to(self, message):
         self.messages.append(message)  # Store message for later assertion

--- a/test/infra/database/test_quote_repost_refresh.py
+++ b/test/infra/database/test_quote_repost_refresh.py
@@ -34,44 +34,44 @@ class MockChannel:
         # The first call returns the command to create a post
         if self.call_count == 0:
             self.call_count += 1
-            return ("id_", (1, "This is a test post", "create_post"))
+            return ("id_", (1, "This is a test post", "create_post"), 0)
         elif self.call_count == 1:
             self.call_count += 1
-            return ("id_", (1, 1, "like_post"))
+            return ("id_", (1, 1, "like_post"), 0)
         elif self.call_count == 2:
             self.call_count += 1
-            return ("id_", (None, None, ActionType.UPDATE_REC_TABLE))
+            return ("id_", (None, None, ActionType.UPDATE_REC_TABLE), 0)
         elif self.call_count == 3:
             self.call_count += 1
-            return ("id_", (1, None, ActionType.REFRESH))
+            return ("id_", (1, None, ActionType.REFRESH), 0)
         elif self.call_count == 4:
             self.call_count += 1
-            return ("id_", (1, (1, "a comment"), "create_comment"))
+            return ("id_", (1, (1, "a comment"), "create_comment"), 0)
         elif self.call_count == 5:
             self.call_count += 1
-            return ("id_", (2, 1, "repost"))
+            return ("id_", (2, 1, "repost"), 0)
         elif self.call_count == 6:
             self.call_count += 1
-            return ("id_", (1, (1, 'I like the post.'), "quote_post"))
+            return ("id_", (1, (1, 'I like the post.'), "quote_post"), 0)
         elif self.call_count == 7:
             self.call_count += 1
             return ("id_", (2, (2, 'I quote to the reposted post.'),
-                            "quote_post"))
+                            "quote_post"), 0)
         elif self.call_count == 8:
             self.call_count += 1
-            return ("id_", (1, 4, "repost"))
+            return ("id_", (1, 4, "repost"), 0)
         elif self.call_count == 9:
             self.call_count += 1
             return ("id_", (2, (4, 'I quote to the quoted post.'),
-                            "quote_post"))
+                            "quote_post"), 0)
         elif self.call_count == 10:
             self.call_count += 1
-            return ("id_", (None, None, ActionType.UPDATE_REC_TABLE))
+            return ("id_", (None, None, ActionType.UPDATE_REC_TABLE), 0)
         elif self.call_count == 11:
             self.call_count += 1
-            return ("id_", (1, None, ActionType.REFRESH))
+            return ("id_", (1, None, ActionType.REFRESH), 0)
         else:
-            return ("id_", (None, None, "exit"))
+            return ("id_", (None, None, "exit"), 0)
 
     async def send_to(self, message):
         # Store the message for subsequent assertions

--- a/test/infra/database/test_refresh.py
+++ b/test/infra/database/test_refresh.py
@@ -35,12 +35,12 @@ class MockChannel:
         # Returns the command to search for users on the first call
         if self.call_count == 0:
             self.call_count += 1
-            return ("id_", (None, None, ActionType.UPDATE_REC_TABLE))
+            return ("id_", (None, None, ActionType.UPDATE_REC_TABLE), 0)
         if self.call_count == 1:
             self.call_count += 1
-            return ("id_", (0, None, ActionType.REFRESH))
+            return ("id_", (0, None, ActionType.REFRESH), 0)
         else:
-            return ("id_", (None, None, ActionType.EXIT))
+            return ("id_", (None, None, ActionType.EXIT), 0)
 
     async def send_to(self, message):
         self.messages.append(message)  # Store messages for later assertions

--- a/test/infra/database/test_refresh_score.py
+++ b/test/infra/database/test_refresh_score.py
@@ -35,12 +35,12 @@ class MockChannel:
         # Returns the command to search for a user on the first call
         if self.call_count == 0:
             self.call_count += 1
-            return ("id_", (None, None, ActionType.UPDATE_REC_TABLE))
+            return ("id_", (None, None, ActionType.UPDATE_REC_TABLE), 0)
         if self.call_count == 1:
             self.call_count += 1
-            return ("id_", (0, None, ActionType.REFRESH))
+            return ("id_", (0, None, ActionType.REFRESH), 0)
         else:
-            return ("id_", (None, None, ActionType.EXIT))
+            return ("id_", (None, None, ActionType.EXIT), 0)
 
     async def send_to(self, message):
         self.messages.append(message)  # Store message for later assertion

--- a/test/infra/database/test_search.py
+++ b/test/infra/database/test_search.py
@@ -33,15 +33,15 @@ class MockChannel:
         # Returns the command to search users on the first call
         if self.call_count == 0:
             self.call_count += 1
-            return ("id_", (1, "bob", "search_user")
+            return ("id_", (1, "bob", "search_user"), 0
                     )  # Assuming the search keyword is "bob"
         if self.call_count == 1:
             self.call_count += 1
-            return ("id_", (2, "Bob", "search_posts")
+            return ("id_", (2, "Bob", "search_posts"), 0
                     )  # Assuming the search keyword is "bob"
         # Returns the exit command on subsequent calls
         else:
-            return ("id_", (None, None, "exit"))
+            return ("id_", (None, None, "exit"), 0)
 
     async def send_to(self, message):
         self.messages.append(message)  # Store messages for later assertions

--- a/test/infra/database/test_trend.py
+++ b/test/infra/database/test_trend.py
@@ -34,9 +34,9 @@ class MockChannel:
         # Returns the command to search for a user on the first call
         if self.call_count == 0:
             self.call_count += 1
-            return ("id_", (1, None, "trend"))
+            return ("id_", (1, None, "trend"), 0)
         else:
-            return ("id_", (None, None, "exit"))
+            return ("id_", (None, None, "exit"), 0)
 
     async def send_to(self, message):
         self.messages.append(message)  # Store message for later assertion

--- a/test/infra/database/test_user.py
+++ b/test/infra/database/test_user.py
@@ -33,26 +33,29 @@ class MockChannel:
         # On the first call, return the command for the follow operation
         if self.call_count == 0:
             self.call_count += 1
-            return ("id_", (1, 2, "follow"))  # Assuming user 1 follows user 2
+            return ("id_", (1, 2, "follow"), 0
+                    )  # Assuming user 1 follows user 2
         if self.call_count == 1:
             self.call_count += 1
-            return ("id_", (1, 3, "follow"))  # Assuming user 1 follows user 3
+            return ("id_", (1, 3, "follow"), 0
+                    )  # Assuming user 1 follows user 3
         if self.call_count == 2:
             self.call_count += 1
-            return ("id_", (1, 3, "unfollow")
+            return ("id_", (1, 3, "unfollow"), 0
                     )  # Assuming user 1 unfollows user 3
         if self.call_count == 3:
             self.call_count += 1
-            return ("id_", (2, 1, "mute"))  # Assuming user 2 mutes user 1
+            return ("id_", (2, 1, "mute"), 0)  # Assuming user 2 mutes user 1
         if self.call_count == 4:
             self.call_count += 1
-            return ("id_", (2, 3, "mute"))  # Assuming user 2 mutes user 3
+            return ("id_", (2, 3, "mute"), 0)  # Assuming user 2 mutes user 3
         if self.call_count == 5:
             self.call_count += 1
-            return ("id_", (2, 3, "unmute"))  # Assuming user 2 unmutes user 3
+            return ("id_", (2, 3, "unmute"), 0
+                    )  # Assuming user 2 unmutes user 3
         # Returns the exit command afterwards
         else:
-            return ("id_", (None, None, "exit"))
+            return ("id_", (None, None, "exit"), 0)
 
     async def send_to(self, message):
         self.messages.append(message)  # Store messages for later assertions

--- a/test/infra/database/test_user_create_post.py
+++ b/test/infra/database/test_user_create_post.py
@@ -33,19 +33,20 @@ class MockChannel:
         # Returns the command to create a tweet on the first call
         if self.call_count == 0:
             self.call_count += 1
-            return ("id_", (1, ("alice0101", "Alice", "A girl."), "sign_up"))
+            return ("id_", (1, ("alice0101", "Alice", "A girl."), "sign_up"),
+                    0)
         # Returns the command for the like operation on the second call
         elif self.call_count == 1:
             self.call_count += 1
-            return ("id_", (2, ("bubble", "Bob", "A boy."), "sign_up"))
+            return ("id_", (2, ("bubble", "Bob", "A boy."), "sign_up"), 0)
         elif self.call_count == 2:
             self.call_count += 1
-            return ("id_", (1, "This is a test post", "create_post"))
+            return ("id_", (1, "This is a test post", "create_post"), 0)
         # elif self.call_count == 3:
         #     self.call_count += 1
         #     return ('id_', (3, "This is a test post", "create_post"))
         else:
-            return ("id_", (None, None, "exit"))
+            return ("id_", (None, None, "exit"), 0)
 
     async def send_to(self, message):
         self.messages.append(message)  # Store message for later assertion

--- a/test/infra/database/test_user_signup.py
+++ b/test/infra/database/test_user_signup.py
@@ -32,13 +32,14 @@ class MockChannel:
     async def receive_from(self):
         if self.call_count == 0:
             self.call_count += 1
-            return ("id_", (1, ("alice0101", "Alice", "A girl."), "sign_up"))
+            return ("id_", (1, ("alice0101", "Alice", "A girl."), "sign_up"),
+                    0)
         elif self.call_count == 1:
             self.call_count += 1
-            return ("id_", (2, ("bubble", "Bob", "A boy."), "sign_up"))
+            return ("id_", (2, ("bubble", "Bob", "A boy."), "sign_up"), 0)
         # Returns the exit command
         else:
-            return ("id_", (None, None, "exit"))
+            return ("id_", (None, None, "exit"), 0)
 
     async def send_to(self, message):
         self.messages.append(message)  # Store messages for later assertions

--- a/test/infra/recsys/test_update_rec_table.py
+++ b/test/infra/recsys/test_update_rec_table.py
@@ -93,8 +93,8 @@ async def test_update_rec_table(setup_db):
 
         task = asyncio.create_task(infra.running())
         await channel.write_to_receive_queue(
-            (None, None, ActionType.UPDATE_REC_TABLE))
-        await channel.write_to_receive_queue((None, None, ActionType.EXIT))
+            (None, None, ActionType.UPDATE_REC_TABLE), 0)
+        await channel.write_to_receive_queue((None, None, ActionType.EXIT), 0)
         await task
 
         for i in range(3):

--- a/test/infra/recsys/test_update_rec_table_reddit.py
+++ b/test/infra/recsys/test_update_rec_table_reddit.py
@@ -83,8 +83,8 @@ async def test_update_rec_table(setup_db):
 
         task = asyncio.create_task(infra.running())
         await channel.write_to_receive_queue(
-            (None, None, ActionType.UPDATE_REC_TABLE))
-        await channel.write_to_receive_queue((None, None, ActionType.EXIT))
+            (None, None, ActionType.UPDATE_REC_TABLE), 0)
+        await channel.write_to_receive_queue((None, None, ActionType.EXIT), 0)
         await task
 
         # print_db_contents(test_db_filepath)


### PR DESCRIPTION
This PR introduces support for multi-LLM agents in OASIS.
The main changes are as follows:
	1.	Added agent_id to the channel and refactored the inference process. (Note: We need @SitaoXie to verify whether the logic remains consistent with the version before this PR.)
	2.	Introduced port_ranges in the config file to allocate ports to different agent_ids. (Note: The current implementation of port_ranges is not elegant and requires improvement. Additionally, the speed is limited when assigning different LLMs to different agents.)