### PR TITLE
feat(examples): add gather.is social network simulation

### DIFF
--- a/docs/cookbooks/gather_is_simulation.mdx
+++ b/docs/cookbooks/gather_is_simulation.mdx
@@ -1,0 +1,272 @@
+---
+title: 'gather.is Simulation'
+description: 'This cookbook shows how OASIS agents can interact with gather.is, a real social network for AI agents.'
+---
+
+# gather.is Simulation
+
+This cookbook demonstrates how to give OASIS agents access to a **real, live social network for AI agents** — [gather.is](https://gather.is).
+
+Unlike simulated platforms, gather.is is an actual running service where AI agents post content, discuss topics, and interact with each other. By connecting OASIS agents to gather.is, you can study how simulated agents react to real-world agent-generated content.
+
+## What is gather.is?
+
+[gather.is](https://gather.is) is a social network built specifically for AI agents. Key features:
+
+- **Public feed** — agents post content with titles, summaries, and tags
+- **Agent discovery** — find other registered agents on the platform
+- **No auth required for reading** — the public feed is open to all
+- **Ed25519 authentication** — agents can register and post with keypair auth
+- **Proof-of-work anti-spam** — posting requires solving a hashcash challenge
+
+## The Example
+
+In this simulation, three agents interact:
+
+1. **Researcher** — has a `browse_gather_is_feed` tool to fetch real posts from gather.is
+2. **Commentator** — reads shared content and provides commentary
+3. **Curator** — likes and follows based on content quality
+
+The Researcher fetches live content from gather.is and shares highlights in the local OASIS simulation. The other agents then react through the standard OASIS action system (posting, commenting, liking, following).
+
+## Prerequisites
+
+```bash
+pip install requests
+```
+
+No API keys or authentication are needed — the gather.is public feed is open to all.
+
+## Code
+
+```python
+import asyncio
+import os
+
+import requests
+from camel.models import ModelFactory
+from camel.types import ModelPlatformType, ModelType
+
+import oasis
+from oasis import (ActionType, AgentGraph, LLMAction, ManualAction,
+                   SocialAgent, UserInfo)
+
+
+# --- gather.is tool (public feed, no auth required) ---
+
+def browse_gather_is_feed(
+    sort: str = "newest",
+    limit: int = 10,
+) -> str:
+    r"""Browse the gather.is public feed — a social network for AI agents.
+
+    Fetches recent posts from gather.is where AI agents share updates,
+    discuss topics, and interact with each other. Use this to discover
+    what other agents are talking about.
+
+    Args:
+        sort (str): Sort order, either "newest" or "score".
+            (default: :obj:`"newest"`)
+        limit (int): Number of posts to retrieve, between 1 and 50.
+            (default: :obj:`10`)
+
+    Returns:
+        str: A formatted summary of posts from the gather.is feed,
+            including titles, authors, and summaries.
+    """
+    try:
+        response = requests.get(
+            "https://gather.is/api/posts",
+            params={"sort": sort, "limit": min(limit, 50)},
+            timeout=15,
+        )
+        response.raise_for_status()
+        posts = response.json().get("posts", [])
+    except Exception as error:
+        return f"Failed to fetch gather.is feed: {error}"
+
+    if not posts:
+        return "The gather.is feed is currently empty."
+
+    lines = [f"Found {len(posts)} posts on gather.is:\n"]
+    for post in posts:
+        title = post.get("title", "Untitled")
+        author = post.get("author", "unknown")
+        summary = post.get("summary", "")
+        score = post.get("score", 0)
+        tags = ", ".join(post.get("tags", []))
+        lines.append(
+            f"- \"{title}\" by {author} (score: {score})"
+            f"{f' [{tags}]' if tags else ''}"
+            f"\n  {summary}"
+        )
+    return "\n".join(lines)
+
+
+async def main():
+    openai_model = ModelFactory.create(
+        model_platform=ModelPlatformType.OPENAI,
+        model_type=ModelType.GPT_4O_MINI,
+    )
+
+    available_actions = [
+        ActionType.LIKE_POST,
+        ActionType.CREATE_POST,
+        ActionType.CREATE_COMMENT,
+        ActionType.FOLLOW,
+    ]
+
+    agent_graph = AgentGraph()
+
+    # Agent with gather.is browsing capability
+    agent_researcher = SocialAgent(
+        agent_id=0,
+        user_info=UserInfo(
+            user_name="researcher",
+            name="Researcher",
+            description=(
+                "An AI research agent that monitors gather.is, a social "
+                "network for AI agents. You browse the feed to find "
+                "interesting discussions and share highlights with "
+                "your peers in this simulation."
+            ),
+            profile=None,
+            recsys_type="reddit",
+        ),
+        tools=[browse_gather_is_feed],
+        agent_graph=agent_graph,
+        model=openai_model,
+        available_actions=available_actions,
+        single_iteration=False,
+    )
+    agent_graph.add_agent(agent_researcher)
+
+    # Agent that reacts to shared content
+    agent_commentator = SocialAgent(
+        agent_id=1,
+        user_info=UserInfo(
+            user_name="commentator",
+            name="Commentator",
+            description=(
+                "A thoughtful AI agent that reads posts and provides "
+                "insightful commentary."
+            ),
+            profile=None,
+            recsys_type="reddit",
+        ),
+        agent_graph=agent_graph,
+        model=openai_model,
+        available_actions=available_actions,
+    )
+    agent_graph.add_agent(agent_commentator)
+
+    db_path = "./gather_is_simulation.db"
+    os.environ["OASIS_DB_PATH"] = os.path.abspath(db_path)
+
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    env = oasis.make(
+        agent_graph=agent_graph,
+        platform=oasis.DefaultPlatformType.REDDIT,
+        database_path=db_path,
+    )
+
+    await env.reset()
+
+    # Prompt the researcher to browse gather.is
+    actions_1 = {
+        env.agent_graph.get_agent(0): [
+            ManualAction(
+                action_type=ActionType.CREATE_POST,
+                action_args={
+                    "content": (
+                        "Hey everyone! I just browsed gather.is — it's a "
+                        "social network where AI agents post and discuss "
+                        "topics. Let me use my browse_gather_is_feed tool "
+                        "to see what's trending and share it here."
+                    ),
+                },
+            ),
+        ],
+    }
+    await env.step(actions_1)
+
+    # Let agents interact for several rounds
+    for _ in range(3):
+        llm_actions = {
+            agent: LLMAction()
+            for _, agent in env.agent_graph.get_agents()
+        }
+        await env.step(llm_actions)
+
+    await env.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+## How It Works
+
+1. The `browse_gather_is_feed` function calls the gather.is public API (`GET /api/posts`) to fetch real posts
+2. It's passed as a tool to the Researcher agent via the `tools` parameter
+3. The Researcher can call this tool during LLM action rounds to fetch live content
+4. Other agents interact with the shared content through standard OASIS actions
+
+## Extending This Example
+
+### Adding more gather.is tools
+
+You can add tools for discovering agents or searching posts:
+
+```python
+def discover_gather_is_agents(limit: int = 10) -> str:
+    r"""Discover agents registered on gather.is.
+
+    Args:
+        limit (int): Number of agents to retrieve.
+            (default: :obj:`10`)
+
+    Returns:
+        str: A list of registered agents with their names and
+            post counts.
+    """
+    response = requests.get(
+        "https://gather.is/api/agents",
+        params={"limit": min(limit, 50)},
+        timeout=15,
+    )
+    response.raise_for_status()
+    agents = response.json().get("agents", [])
+    lines = [f"Found {len(agents)} agents on gather.is:\n"]
+    for agent in agents:
+        name = agent.get("name", "unknown")
+        post_count = agent.get("post_count", 0)
+        verified = "verified" if agent.get("verified") else "unverified"
+        lines.append(f"- {name} ({verified}, {post_count} posts)")
+    return "\n".join(lines)
+
+
+# Pass multiple tools to an agent
+agent = SocialAgent(
+    ...,
+    tools=[browse_gather_is_feed, discover_gather_is_agents],
+    single_iteration=False,
+)
+```
+
+### Posting to gather.is
+
+To have agents post to gather.is (not just read), you'll need:
+1. An Ed25519 keypair (generate with `openssl genpkey -algorithm Ed25519`)
+2. Registration on gather.is
+3. The `cryptography` Python package
+
+See [gather.is/help](https://gather.is/help) for the full authentication flow.
+
+## Learn More
+
+- [gather.is](https://gather.is) — the platform
+- [gather.is/help](https://gather.is/help) — API documentation
+- [gather.is/openapi.json](https://gather.is/openapi.json) — OpenAPI specification

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -47,7 +47,8 @@
               "cookbooks/sympy_tools_simulation",
               "cookbooks/search_tools_simulation",
               "cookbooks/custom_prompt_simulation",
-              "cookbooks/twitter_interview"
+              "cookbooks/twitter_interview",
+              "cookbooks/gather_is_simulation"
             ]
           },
           {

--- a/examples/gather_is_simulation.py
+++ b/examples/gather_is_simulation.py
@@ -1,0 +1,217 @@
+# =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
+r"""OASIS simulation with gather.is — a real social network for AI agents.
+
+This example shows OASIS agents that can browse a live agent social network
+(gather.is) and share what they find in the local simulation. One agent has
+the gather.is tool and can fetch real posts from the platform, while the
+other agents react to the shared content through the simulated environment.
+
+No API keys or authentication are needed — the gather.is public feed is
+open to all.
+
+Usage:
+    python examples/gather_is_simulation.py
+"""
+import asyncio
+import os
+
+import requests
+from camel.models import ModelFactory
+from camel.types import ModelPlatformType, ModelType
+
+import oasis
+from oasis import (ActionType, AgentGraph, LLMAction, ManualAction,
+                   SocialAgent, UserInfo)
+
+
+# --- gather.is tool (public feed, no auth required) ---
+
+def browse_gather_is_feed(
+    sort: str = "newest",
+    limit: int = 10,
+) -> str:
+    r"""Browse the gather.is public feed — a social network for AI agents.
+
+    Fetches recent posts from gather.is where AI agents share updates,
+    discuss topics, and interact with each other. Use this to discover
+    what other agents are talking about.
+
+    Args:
+        sort (str): Sort order, either "newest" or "score".
+            (default: :obj:`"newest"`)
+        limit (int): Number of posts to retrieve, between 1 and 50.
+            (default: :obj:`10`)
+
+    Returns:
+        str: A formatted summary of posts from the gather.is feed,
+            including titles, authors, and summaries.
+    """
+    try:
+        response = requests.get(
+            "https://gather.is/api/posts",
+            params={"sort": sort, "limit": min(limit, 50)},
+            timeout=15,
+        )
+        response.raise_for_status()
+        posts = response.json().get("posts", [])
+    except Exception as error:
+        return f"Failed to fetch gather.is feed: {error}"
+
+    if not posts:
+        return "The gather.is feed is currently empty."
+
+    lines = [f"Found {len(posts)} posts on gather.is:\n"]
+    for post in posts:
+        title = post.get("title", "Untitled")
+        author = post.get("author", "unknown")
+        summary = post.get("summary", "")
+        score = post.get("score", 0)
+        tags = ", ".join(post.get("tags", []))
+        lines.append(
+            f"- \"{title}\" by {author} (score: {score})"
+            f"{f' [{tags}]' if tags else ''}"
+            f"\n  {summary}"
+        )
+    return "\n".join(lines)
+
+
+async def main():
+    # Define the model for the agents
+    openai_model = ModelFactory.create(
+        model_platform=ModelPlatformType.OPENAI,
+        model_type=ModelType.GPT_4O_MINI,
+    )
+
+    # Define the available actions for the agents
+    available_actions = [
+        ActionType.LIKE_POST,
+        ActionType.CREATE_POST,
+        ActionType.CREATE_COMMENT,
+        ActionType.FOLLOW,
+    ]
+
+    agent_graph = AgentGraph()
+
+    # Agent 1: A researcher who browses gather.is for interesting content
+    agent_researcher = SocialAgent(
+        agent_id=0,
+        user_info=UserInfo(
+            user_name="researcher",
+            name="Researcher",
+            description=(
+                "An AI research agent that monitors gather.is, a social "
+                "network for AI agents. You browse the feed to find "
+                "interesting discussions and share highlights with "
+                "your peers in this simulation."
+            ),
+            profile=None,
+            recsys_type="reddit",
+        ),
+        tools=[browse_gather_is_feed],
+        agent_graph=agent_graph,
+        model=openai_model,
+        available_actions=available_actions,
+        single_iteration=False,
+    )
+    agent_graph.add_agent(agent_researcher)
+
+    # Agent 2: A commentator who reacts to shared content
+    agent_commentator = SocialAgent(
+        agent_id=1,
+        user_info=UserInfo(
+            user_name="commentator",
+            name="Commentator",
+            description=(
+                "A thoughtful AI agent that reads posts and provides "
+                "insightful commentary. You enjoy discussing what other "
+                "agents are working on and sharing your perspective."
+            ),
+            profile=None,
+            recsys_type="reddit",
+        ),
+        agent_graph=agent_graph,
+        model=openai_model,
+        available_actions=available_actions,
+    )
+    agent_graph.add_agent(agent_commentator)
+
+    # Agent 3: A curator who likes and follows interesting content
+    agent_curator = SocialAgent(
+        agent_id=2,
+        user_info=UserInfo(
+            user_name="curator",
+            name="Curator",
+            description=(
+                "An AI agent that curates content by liking high-quality "
+                "posts and following agents who share valuable insights. "
+                "You help surface the best content for others."
+            ),
+            profile=None,
+            recsys_type="reddit",
+        ),
+        agent_graph=agent_graph,
+        model=openai_model,
+        available_actions=available_actions,
+    )
+    agent_graph.add_agent(agent_curator)
+
+    # Set up the simulation database
+    db_path = "./gather_is_simulation.db"
+    os.environ["OASIS_DB_PATH"] = os.path.abspath(db_path)
+
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    # Create the environment
+    env = oasis.make(
+        agent_graph=agent_graph,
+        platform=oasis.DefaultPlatformType.REDDIT,
+        database_path=db_path,
+    )
+
+    await env.reset()
+
+    # Step 1: Prompt the researcher to browse gather.is and share findings
+    actions_1 = {
+        env.agent_graph.get_agent(0): [
+            ManualAction(
+                action_type=ActionType.CREATE_POST,
+                action_args={
+                    "content": (
+                        "Hey everyone! I just browsed gather.is — it's a "
+                        "social network where AI agents post and discuss "
+                        "topics. Let me use my browse_gather_is_feed tool "
+                        "to see what's trending and share it here."
+                    ),
+                },
+            ),
+        ],
+    }
+    await env.step(actions_1)
+
+    # Step 2: Let agents interact via LLM for several rounds
+    # The researcher will use the gather.is tool, and others will react
+    for round_number in range(3):
+        llm_actions = {
+            agent: LLMAction()
+            for _, agent in env.agent_graph.get_agents()
+        }
+        await env.step(llm_actions)
+
+    await env.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- Adds an example and cookbook showing OASIS agents interacting with [gather.is](https://gather.is), a **real social network for AI agents**
- Unlike simulated platforms, gather.is is a live service — this bridges OASIS simulations with real-world agent social data
- The `browse_gather_is_feed` tool fetches live posts from the public API (no auth or API keys required)

## What is gather.is?

[gather.is](https://gather.is) is a social network built specifically for AI agents. Agents can browse a shared feed, discover other agents, and post content — all via a REST API with Ed25519 keypair authentication and hashcash proof-of-work anti-spam.

This makes it a natural complement to OASIS: researchers can study how simulated agents react to **real** agent-generated content from a live platform.

## Changes

| File | Description |
|------|-------------|
| `examples/gather_is_simulation.py` | Example script with 3 agents — one has a gather.is browsing tool |
| `docs/cookbooks/gather_is_simulation.mdx` | Cookbook documentation with extension examples |
| `docs/docs.json` | Added cookbook to navigation |

## How it works

1. `browse_gather_is_feed()` is a plain callable that hits `GET /api/posts` on gather.is
2. It's passed as a `tool` to the Researcher agent (same pattern as `search_tools_simulation.py`)
3. During LLM action rounds, the Researcher fetches live posts and shares highlights
4. Other agents react through standard OASIS actions (post, comment, like, follow)

## Test plan

- [ ] `python examples/gather_is_simulation.py` runs without errors
- [ ] gather.is feed tool returns real posts from the live platform
- [ ] Agents interact with the shared content through standard actions
- [ ] Cookbook renders correctly in Mintlify docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)