### PR TITLE
fix(recsys): resolve KeyError 'post_id' in rec_sys_personalized_with_trace

### DIFF
--- a/oasis/social_platform/recsys.py
+++ b/oasis/social_platform/recsys.py
@@ -721,6 +721,14 @@ def rec_sys_personalized_with_trace(
     if len(post_ids) <= max_rec_post_len:
         new_rec_matrix = [post_ids] * (len(rec_matrix) - 1)
     else:
+        # Pre-compute traced post IDs once outside the per-user loop (Fix: avoid
+        # redundant recomputation; trace_table does not change per user)
+        if swap_rate > 0:
+            traced_post_ids = {
+                literal_eval(trace['info']).get('post_id')
+                for trace in trace_table
+                if trace.get('user_id') is not None
+            }
         for idx in range(1, len(rec_matrix)):
             user_id = user_table[idx - 1]['user_id']
             user_bio = user_table[idx - 1]['bio']
@@ -781,11 +789,6 @@ def rec_sys_personalized_with_trace(
 
             if swap_rate > 0:
                 # swap the recommended posts with random posts
-                traced_post_ids = {
-                    literal_eval(trace['info']).get('post_id')
-                    for trace in trace_table
-                    if trace.get('user_id') is not None
-                }
                 swap_free_ids = [
                     post_id for post_id in post_ids
                     if post_id not in rec_post_ids

--- a/oasis/social_platform/recsys.py
+++ b/oasis/social_platform/recsys.py
@@ -781,12 +781,15 @@ def rec_sys_personalized_with_trace(
 
             if swap_rate > 0:
                 # swap the recommended posts with random posts
+                traced_post_ids = {
+                    literal_eval(trace['info']).get('post_id')
+                    for trace in trace_table
+                    if trace.get('user_id')
+                }
                 swap_free_ids = [
                     post_id for post_id in post_ids
-                    if post_id not in rec_post_ids and post_id not in [
-                        trace['post_id']
-                        for trace in trace_table if trace['user_id']
-                    ]
+                    if post_id not in rec_post_ids
+                    and post_id not in traced_post_ids
                 ]
                 rec_post_ids = swap_random_posts(rec_post_ids, swap_free_ids,
                                                  swap_rate)

--- a/oasis/social_platform/recsys.py
+++ b/oasis/social_platform/recsys.py
@@ -784,7 +784,7 @@ def rec_sys_personalized_with_trace(
                 traced_post_ids = {
                     literal_eval(trace['info']).get('post_id')
                     for trace in trace_table
-                    if trace.get('user_id')
+                    if trace.get('user_id') is not None
                 }
                 swap_free_ids = [
                     post_id for post_id in post_ids

--- a/tests/test_recsys_trace.py
+++ b/tests/test_recsys_trace.py
@@ -1,0 +1,166 @@
+"""
+Unit tests for rec_sys_personalized_with_trace()
+Covers swap_rate > 0 with trace rows that lack a post_id (e.g. follow/unfollow actions).
+"""
+
+import json
+import unittest
+from ast import literal_eval
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs so we can import the function without the full oasis stack
+# ---------------------------------------------------------------------------
+
+def _make_trace(user_id, action, post_id=None):
+    """Helper to build a trace row matching the actual schema."""
+    info = {"post_id": post_id} if post_id is not None else {"target_id": user_id + 1}
+    return {
+        "user_id": user_id,
+        "action": action,
+        "info": str(info),  # stored as stringified dict (literal_eval-able)
+    }
+
+
+def _make_user(user_id, agent_id=None):
+    return {
+        "user_id": user_id,
+        "agent_id": agent_id if agent_id is not None else user_id,
+        "bio": "test bio",
+    }
+
+
+def _make_post(post_id, user_id, content="hello"):
+    return {"post_id": post_id, "user_id": user_id, "content": content}
+
+
+# ---------------------------------------------------------------------------
+# Import the actual function under test
+# ---------------------------------------------------------------------------
+
+import sys
+import os
+
+# Allow running from repo root
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+try:
+    from oasis.social_platform.recsys import rec_sys_personalized_with_trace
+    IMPORT_OK = True
+except Exception:
+    IMPORT_OK = False
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(IMPORT_OK, "oasis package not importable in this env")
+class TestRecSysPersonalizedWithTrace(unittest.TestCase):
+
+    def _base_args(self):
+        """Minimal valid inputs for the function."""
+        users = [_make_user(1), _make_user(2)]
+        posts = [_make_post(i, user_id=99) for i in range(1, 12)]  # 11 posts
+        rec_matrix = [[], [1, 2, 3], [1, 2, 3]]  # row 0 unused; one row per user
+        return users, posts, rec_matrix
+
+    # ------------------------------------------------------------------
+    # Fix #1 regression: user_id=0 must NOT be treated as falsy
+    # ------------------------------------------------------------------
+
+    def test_user_id_zero_not_excluded_from_traced_ids(self):
+        """Traces from user_id=0 must be included in traced_post_ids."""
+        users, posts, rec_matrix = self._base_args()
+        trace_table = [
+            _make_trace(user_id=0, action="like", post_id=1),
+            _make_trace(user_id=1, action="like", post_id=2),
+        ]
+        # Should not raise; post_id=1 traced by user 0 must be tracked
+        try:
+            result = rec_sys_personalized_with_trace(
+                users, posts, trace_table, rec_matrix,
+                max_rec_post_len=5, swap_rate=0.2, model=None
+            )
+        except KeyError as e:
+            self.fail(f"KeyError raised — user_id=0 trace was skipped: {e}")
+        self.assertIsInstance(result, list)
+
+    # ------------------------------------------------------------------
+    # Fix #2 regression: traced_post_ids computed only once (perf)
+    # We verify correctness rather than call count (no easy hook without
+    # refactoring), so we assert the result is consistent across users.
+    # ------------------------------------------------------------------
+
+    def test_traced_post_ids_consistent_across_users(self):
+        """All users should see the same global traced_post_ids set."""
+        users = [_make_user(i) for i in range(1, 4)]
+        posts = [_make_post(i, user_id=99) for i in range(1, 15)]
+        rec_matrix = [[], []] * 4  # one slot per user + unused row 0
+        trace_table = [
+            _make_trace(user_id=1, action="like", post_id=3),
+            _make_trace(user_id=2, action="like", post_id=3),
+        ]
+        result = rec_sys_personalized_with_trace(
+            users, posts, trace_table, rec_matrix,
+            max_rec_post_len=5, swap_rate=0.5, model=None
+        )
+        # post_id=3 is traced; it should not appear in swap_free candidates
+        # (the exact rec list is random, but no assertion errors should occur)
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), len(users))
+
+    # ------------------------------------------------------------------
+    # Fix #3 (core): non-post traces (follow/unfollow) must not raise
+    # ------------------------------------------------------------------
+
+    def test_swap_rate_with_non_post_traces_no_keyerror(self):
+        """
+        rec_sys_personalized_with_trace must not raise KeyError when
+        trace_table contains follow/unfollow rows that have no post_id in info.
+        """
+        users, posts, rec_matrix = self._base_args()
+        trace_table = [
+            _make_trace(user_id=1, action="like",   post_id=2),
+            _make_trace(user_id=1, action="follow",  post_id=None),   # no post_id
+            _make_trace(user_id=1, action="unfollow", post_id=None),  # no post_id
+            _make_trace(user_id=2, action="like",   post_id=5),
+        ]
+        try:
+            result = rec_sys_personalized_with_trace(
+                users, posts, trace_table, rec_matrix,
+                max_rec_post_len=5, swap_rate=0.3, model=None
+            )
+        except KeyError as e:
+            self.fail(
+                f"KeyError raised on non-post trace row (follow/unfollow): {e}"
+            )
+        self.assertIsInstance(result, list)
+
+    def test_swap_rate_zero_skips_trace_computation(self):
+        """With swap_rate=0, traced_post_ids should not be computed at all."""
+        users, posts, rec_matrix = self._base_args()
+        # Deliberately broken trace to catch accidental computation
+        trace_table = [{"user_id": 1, "action": "like", "info": "NOT_VALID_JSON"}]
+        try:
+            result = rec_sys_personalized_with_trace(
+                users, posts, trace_table, rec_matrix,
+                max_rec_post_len=5, swap_rate=0.0, model=None
+            )
+        except Exception as e:
+            self.fail(f"swap_rate=0 should not touch trace_table, but raised: {e}")
+        self.assertIsInstance(result, list)
+
+    def test_empty_trace_table_with_swap(self):
+        """Empty trace table with swap_rate > 0 must work without errors."""
+        users, posts, rec_matrix = self._base_args()
+        result = rec_sys_personalized_with_trace(
+            users, posts, [], rec_matrix,
+            max_rec_post_len=5, swap_rate=0.5, model=None
+        )
+        self.assertIsInstance(result, list)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #198

## Problem

Calling `platform.update_rec_table()` with a non-zero `swap_rate` raises `KeyError: 'post_id'`:

```
File "oasis/social_platform/recsys.py", line 787
    trace['post_id']
KeyError: 'post_id'
```

## Root Cause

The `trace` table schema stores interaction data in an `info TEXT` column as a JSON string — there is no top-level `post_id` column (see `schema/trace.sql`). The code at line 787 accessed `trace['post_id']` directly, which does not exist.

The rest of the codebase correctly reads post IDs from the `info` field via `literal_eval(trace['info'])["post_id"]` (e.g. `get_like_post_id()` at L371).

## Fix

Replace the direct `trace['post_id']` access with `literal_eval(trace['info']).get('post_id')`, consistent with the existing pattern. Use `.get()` instead of `[]` to safely skip trace entries for actions that do not produce a `post_id` (e.g. follow, retweet). Pre-compute the set of traced post IDs outside the list comprehension to avoid redundant work per post.

## Before / After

```python
# Before (raises KeyError)
swap_free_ids = [
    post_id for post_id in post_ids
    if post_id not in rec_post_ids and post_id not in [
        trace['post_id']
        for trace in trace_table if trace['user_id']
    ]
]

# After
traced_post_ids = {
    literal_eval(trace['info']).get('post_id')
    for trace in trace_table
    if trace.get('user_id')
}
swap_free_ids = [
    post_id for post_id in post_ids
    if post_id not in rec_post_ids
    and post_id not in traced_post_ids
]
```