### PR TITLE
fix(database): add explicit encoding="utf-8" to SQL schema loaders

### DIFF
--- a/oasis/social_platform/database.py
+++ b/oasis/social_platform/database.py
@@ -97,98 +97,98 @@ def create_db(db_path: str | None = None):
     try:
         # Read and execute the user table SQL script:
         user_sql_path = osp.join(schema_dir, USER_SCHEMA_SQL)
-        with open(user_sql_path, "r") as sql_file:
+        with open(user_sql_path, "r", encoding="utf-8") as sql_file:
             user_sql_script = sql_file.read()
         cursor.executescript(user_sql_script)
 
         # Read and execute the post table SQL script:
         post_sql_path = osp.join(schema_dir, POST_SCHEMA_SQL)
-        with open(post_sql_path, "r") as sql_file:
+        with open(post_sql_path, "r", encoding="utf-8") as sql_file:
             post_sql_script = sql_file.read()
         cursor.executescript(post_sql_script)
 
         # Read and execute the follow table SQL script:
         follow_sql_path = osp.join(schema_dir, FOLLOW_SCHEMA_SQL)
-        with open(follow_sql_path, "r") as sql_file:
+        with open(follow_sql_path, "r", encoding="utf-8") as sql_file:
             follow_sql_script = sql_file.read()
         cursor.executescript(follow_sql_script)
 
         # Read and execute the mute table SQL script:
         mute_sql_path = osp.join(schema_dir, MUTE_SCHEMA_SQL)
-        with open(mute_sql_path, "r") as sql_file:
+        with open(mute_sql_path, "r", encoding="utf-8") as sql_file:
             mute_sql_script = sql_file.read()
         cursor.executescript(mute_sql_script)
 
         # Read and execute the like table SQL script:
         like_sql_path = osp.join(schema_dir, LIKE_SCHEMA_SQL)
-        with open(like_sql_path, "r") as sql_file:
+        with open(like_sql_path, "r", encoding="utf-8") as sql_file:
             like_sql_script = sql_file.read()
         cursor.executescript(like_sql_script)
 
         # Read and execute the dislike table SQL script:
         dislike_sql_path = osp.join(schema_dir, DISLIKE_SCHEMA_SQL)
-        with open(dislike_sql_path, "r") as sql_file:
+        with open(dislike_sql_path, "r", encoding="utf-8") as sql_file:
             dislike_sql_script = sql_file.read()
         cursor.executescript(dislike_sql_script)
 
         # Read and execute the report table SQL script:
         report_sql_path = osp.join(schema_dir, REPORT_SCHEAM_SQL)
-        with open(report_sql_path, "r") as sql_file:
+        with open(report_sql_path, "r", encoding="utf-8") as sql_file:
             report_sql_script = sql_file.read()
         cursor.executescript(report_sql_script)
 
         # Read and execute the trace table SQL script:
         trace_sql_path = osp.join(schema_dir, TRACE_SCHEMA_SQL)
-        with open(trace_sql_path, "r") as sql_file:
+        with open(trace_sql_path, "r", encoding="utf-8") as sql_file:
             trace_sql_script = sql_file.read()
         cursor.executescript(trace_sql_script)
 
         # Read and execute the rec table SQL script:
         rec_sql_path = osp.join(schema_dir, REC_SCHEMA_SQL)
-        with open(rec_sql_path, "r") as sql_file:
+        with open(rec_sql_path, "r", encoding="utf-8") as sql_file:
             rec_sql_script = sql_file.read()
         cursor.executescript(rec_sql_script)
 
         # Read and execute the comment table SQL script:
         comment_sql_path = osp.join(schema_dir, COMMENT_SCHEMA_SQL)
-        with open(comment_sql_path, "r") as sql_file:
+        with open(comment_sql_path, "r", encoding="utf-8") as sql_file:
             comment_sql_script = sql_file.read()
         cursor.executescript(comment_sql_script)
 
         # Read and execute the comment_like table SQL script:
         comment_like_sql_path = osp.join(schema_dir, COMMENT_LIKE_SCHEMA_SQL)
-        with open(comment_like_sql_path, "r") as sql_file:
+        with open(comment_like_sql_path, "r", encoding="utf-8") as sql_file:
             comment_like_sql_script = sql_file.read()
         cursor.executescript(comment_like_sql_script)
 
         # Read and execute the comment_dislike table SQL script:
         comment_dislike_sql_path = osp.join(schema_dir,
                                             COMMENT_DISLIKE_SCHEMA_SQL)
-        with open(comment_dislike_sql_path, "r") as sql_file:
+        with open(comment_dislike_sql_path, "r", encoding="utf-8") as sql_file:
             comment_dislike_sql_script = sql_file.read()
         cursor.executescript(comment_dislike_sql_script)
 
         # Read and execute the product table SQL script:
         product_sql_path = osp.join(schema_dir, PRODUCT_SCHEMA_SQL)
-        with open(product_sql_path, "r") as sql_file:
+        with open(product_sql_path, "r", encoding="utf-8") as sql_file:
             product_sql_script = sql_file.read()
         cursor.executescript(product_sql_script)
 
         # Read and execute the group table SQL script:
         group_sql_path = osp.join(schema_dir, GROUP_SCHEMA_SQL)
-        with open(group_sql_path, "r") as sql_file:
+        with open(group_sql_path, "r", encoding="utf-8") as sql_file:
             group_sql_script = sql_file.read()
         cursor.executescript(group_sql_script)
 
         # Read and execute the group_member table SQL script:
         group_member_sql_path = osp.join(schema_dir, GROUP_MEMBER_SCHEMA_SQL)
-        with open(group_member_sql_path, "r") as sql_file:
+        with open(group_member_sql_path, "r", encoding="utf-8") as sql_file:
             group_member_sql_script = sql_file.read()
         cursor.executescript(group_member_sql_script)
 
         # Read and execute the group_message table SQL script:
         group_message_sql_path = osp.join(schema_dir, GROUP_MESSAGE_SCHEMA_SQL)
-        with open(group_message_sql_path, "r") as sql_file:
+        with open(group_message_sql_path, "r", encoding="utf-8") as sql_file:
             group_message_sql_script = sql_file.read()
         cursor.executescript(group_message_sql_script)
 


### PR DESCRIPTION
## What

The 16 `open()` calls in `oasis/social_platform/database.py` that load SQL schema files (`user_sql_path`, `post_sql_path`, `follow_sql_path`, `like_sql_path`, ... 16 total) are text-mode opens without an explicit `encoding=` argument. Python falls back to `locale.getpreferredencoding()`, which is `cp1252` on Windows and `utf-8` on Linux/macOS.

## Why

- SQL schema files that contain any non-ASCII content (e.g. test seed data with international usernames, post bodies, comment text) will fail to load with `UnicodeDecodeError` on Windows or under a non-utf-8 locale.
- Simulation reproducibility across machines — current behavior is silently locale-dependent.
- PEP 597 recommends always specifying `encoding=` for text-mode opens.
- Eliminates `EncodingWarning` under `PYTHONWARNDEFAULTENCODING=1` (Python 3.10+).
- No behavior change on systems where the default is already utf-8.

## Changes

`oasis/social_platform/database.py`: added `encoding="utf-8"` to all 16 SQL-loader `open()` calls covering:

`user`, `post`, `follow`, `mute`, `like`, `dislike`, `report`, `trace`, `rec`, `comment`, `comment_like`, `comment_dislike`, `product`, `group`, `group_member`, `group_message`.

Total: +16/-16 lines, 1 file.

## Testing

Pure keyword-argument addition to `open()`; no logic touched. Verified the file parses cleanly with `python -m py_compile`. The SQL files were already being read as utf-8 in practice on Linux/macOS — this just makes it explicit and portable to Windows.