### PR TITLE
SocialSense Core Foundation: reusable social media simulation layer from OASIS research base

### DIFF
--- a/docs/socialsense/BEHAVIOR_MODULE_MODEL.md
+++ b/docs/socialsense/BEHAVIOR_MODULE_MODEL.md
@@ -1,0 +1,22 @@
+# Behavior Module Model
+
+SocialSense models reusable behavior modules first, then maps platforms onto those modules.
+
+## Modules
+
+| Module | Actions |
+|---|---|
+| Public Feed | `post`, `comment`, `react`, `share`, `follow`, `refresh_feed` |
+| Community Group | `create_group`, `join_group`, `leave_group`, `post_topic`, `reply`, `moderate` |
+| Private Messaging | `send_message`, `reply_message`, `forward_message`, `create_chat_group`, `listen_group` |
+| Short Video | `publish_video`, `watch_video`, `skip_video`, `like_video`, `comment_video`, `share_video`, `follow_creator` |
+| Long-form Video | `publish_long_video`, `watch_long_video`, `subscribe_channel`, `comment_video`, `share_video` |
+| Influencer Network | `follow_influencer`, `trust_influencer`, `amplify_content`, `creator_endorsement` |
+| Recommendation / Discovery | `discover_content`, `rank_feed`, `search_topic`, `trend_topic` |
+| Information Diffusion | `expose_content`, `propagate_content`, `decay_attention` |
+| Opinion Formation | `update_sentiment`, `update_belief`, `update_intent` |
+| Trust / Credibility | `evaluate_source_trust`, `update_trust_score` |
+| Social Commerce | `view_product`, `ask_for_review`, `purchase_intent`, `share_deal` |
+| Crisis Spread | `crisis_alert`, `rumor_spread`, `official_response`, `correction_spread` |
+
+Each module declares actions and optional signal types. The simulation runner validates actions through the action registry and records events.

--- a/docs/socialsense/CODE_REVIEW.md
+++ b/docs/socialsense/CODE_REVIEW.md
@@ -1,0 +1,204 @@
+# SocialSense Core Foundation Code Review
+
+Verdict: APPROVED
+
+Review date: 2026-06-24
+Reviewer role: code-reviewer
+Scope: Current branch `feature/socialsense-core-foundation` in `/Users/chawit/Projects/oasis-socialsense-research`, focused on the new SocialSense foundation files under `socialsense_core/`, `tests/socialsense/`, `examples/socialsense_*_demo.py`, and `docs/socialsense/`.
+
+## Acceptance criteria reviewed
+
+- Modular architecture with clear core abstractions.
+- Platform-agnostic core model and simulation runner.
+- Platform presets separated from core execution logic.
+- No CivicSense hard dependency in reusable core.
+- No real credentials, live API calls, scraping, or live platform access in the SocialSense foundation.
+- Clear tests, examples, and documentation.
+- Review output limited to this file.
+
+## Evidence
+
+### Repository / branch state
+
+Command executed:
+
+```bash
+git status --short && git branch --show-current && git diff --stat
+```
+
+Observed output summary:
+
+- Current branch: `feature/socialsense-core-foundation`
+- New untracked SocialSense areas present:
+  - `socialsense_core/`
+  - `tests/socialsense/`
+  - `docs/socialsense/`
+  - `examples/socialsense_*.py`
+
+Note: Because the SocialSense files are currently untracked, `git diff --stat` did not show tracked diff details for them. Review therefore used direct filesystem inspection and targeted tests.
+
+### Lightweight tests executed
+
+Command executed:
+
+```bash
+python -m pytest tests/socialsense -q
+```
+
+Result:
+
+```text
+...............                                                          [100%]
+15 passed in 0.02s
+```
+
+Command executed:
+
+```bash
+python -m pytest tests/socialsense/test_examples_import.py -q
+```
+
+Result:
+
+```text
+.                                                                        [100%]
+1 passed in 0.01s
+```
+
+Example demos were also executed directly. They produced deterministic synthetic summaries for 3C, CivicSense adapter demo, Facebook, LINE, Thai platform mix, TikTok, and YouTube scenarios. The outputs showed synthetic action logs and the disclaimer: `Synthetic deterministic simulation; no live platform access or real PII.`
+
+### Architecture inspection
+
+Inspected files included:
+
+- `socialsense_core/__init__.py`
+- `socialsense_core/actions/types.py`
+- `socialsense_core/actions/registry.py`
+- `socialsense_core/behaviors/types.py`
+- `socialsense_core/behaviors/registry.py`
+- `socialsense_core/platforms/base.py`
+- `socialsense_core/platforms/registry.py`
+- `socialsense_core/platforms/{x_twitter,reddit,line,facebook,tiktok,youtube}.py`
+- `socialsense_core/recommendation/base.py`
+- `socialsense_core/recommendation/heuristics.py`
+- `socialsense_core/simulation/context.py`
+- `socialsense_core/simulation/runner.py`
+- `socialsense_core/simulation/result.py`
+- `socialsense_core/adapters/civicsense_adapter.py`
+- `socialsense_core/adapters/threec_marketing_adapter.py`
+- `tests/socialsense/*.py`
+- `docs/socialsense/*.md`
+- `examples/socialsense_*_demo.py`
+
+The core package is built from small dataclass- and registry-oriented modules. Imports are local to `socialsense_core` and Python standard library for the inspected core. The deterministic runner validates action types, emits a synthetic event log, and derives recommendation, diffusion, opinion, and trust signals without external services.
+
+### Dependency and safety search
+
+Targeted search over `socialsense_core/` for CivicSense coupling, live network clients, scraping terms, API credentials, and environment-secret access returned no matches for:
+
+- `CivicSense` / `civicsense`
+- `requests.` / `httpx` / `aiohttp`
+- `selenium` / `playwright`
+- `scrap` / `crawl`
+- `api_key` / `secret` / `token` / `password`
+- `os.environ` / `getenv`
+
+Targeted search over `examples/socialsense*.py` found only the expected import of `socialsense_core.adapters.civicsense_adapter` in `examples/socialsense_civicsense_adapter_demo.py`; no credential, live API, scraping, or environment-secret usage was found in those SocialSense demo files.
+
+## Findings
+
+### 1. Modular architecture: PASS
+
+The architecture is split into clear modules:
+
+- Actions: normalized `SocialAction` definitions and action registry.
+- Behaviors: `SocialBehaviorModule` and behavior registry.
+- Platforms: `SocialPlatformPreset` plus separate platform preset files.
+- Personas/content: platform-neutral `SocialActor` and `SocialContent`.
+- Events: `SocialEvent` and `EventLog`.
+- Signals: recommendation, diffusion, opinion, and trust signal dataclasses.
+- Simulation: `SimulationContext`, deterministic runner, and `SimulationResult`.
+- Adapters: vertical-specific helper adapters kept outside the core runner.
+
+This satisfies the modular foundation requirement.
+
+### 2. Platform-agnostic core: PASS
+
+Core abstractions use normalized concepts rather than concrete platform APIs. `SocialAction.platform` is optional metadata, platform behavior is described through presets, and `DeterministicSimulationRunner` operates over `SimulationContext` and action registry entries instead of LINE/Facebook/TikTok/YouTube/X/Reddit-specific clients.
+
+The core is synthetic and deterministic by default, with explicit runtime mode and provenance labels.
+
+### 3. Separated platform presets: PASS
+
+Platform presets are separated under `socialsense_core/platforms/`:
+
+- `x_twitter.py`
+- `reddit.py`
+- `line.py`
+- `facebook.py`
+- `tiktok.py`
+- `youtube.py`
+
+`PlatformPresetRegistry` composes those presets without embedding platform-specific execution logic in the simulation runner. Tests verify expected platform-to-behavior mappings.
+
+### 4. No CivicSense hard dependency: PASS
+
+The reusable core does not import CivicSense modules or depend on CivicSense runtime code. The CivicSense-specific bridge exists as `socialsense_core/adapters/civicsense_adapter.py`, and it maps scenario inputs into generic SocialSense objects before calling `run_simulation`.
+
+This is acceptable because CivicSense is represented as an optional vertical adapter, not as a core dependency.
+
+### 5. No real credentials/APIs/scraping: PASS
+
+The inspected SocialSense foundation does not use live network clients, scraping/browser automation libraries, credential variables, or environment-secret access. Simulation outputs are synthetic and deterministic.
+
+Existing upstream repository files outside the SocialSense foundation include historical examples and dependencies mentioning OpenAI, tokens, and scraping-related packages. Those appear outside the reviewed SocialSense foundation scope and were not introduced or required by the new core. They should not be confused with the SocialSense core implementation.
+
+### 6. Tests/examples/docs: PASS
+
+Tests are present under `tests/socialsense/` and cover:
+
+- Core public abstractions.
+- Behavior and platform registries.
+- Simulation context/result governance hooks.
+- Event log behavior.
+- Recommendation/diffusion/opinion heuristics.
+- Runtime modes.
+- Adapter interfaces.
+- Example importability.
+
+Docs are present under `docs/socialsense/`, including architecture, platform preset model, behavior module model, runtime modes, integration plans, quickstart, roadmap, and QA report.
+
+Examples are present and runnable under `examples/socialsense_*_demo.py` for platform and adapter scenarios.
+
+## Issues
+
+No blocking issues found.
+
+## Non-blocking observations / recommendations
+
+1. Packaging inclusion has been addressed after the initial review.
+   - `pyproject.toml` now lists both `{ include = "oasis" }` and `{ include = "socialsense_core" }` under Poetry packages.
+   - Direct tests pass from the repository root and the reusable package is included in Poetry packaging metadata.
+
+2. CI should add the SocialSense test subset explicitly.
+   - The command `python -m pytest tests/socialsense -q` is fast and should be safe for pre-merge validation.
+
+3. Some docs use broad future-oriented language.
+   - That is acceptable for a foundation branch, but future implementation PRs should keep docs synchronized with actual runtime behavior as the model evolves beyond deterministic heuristics.
+
+4. The current runner is intentionally deterministic and lightweight.
+   - This is suitable for the foundation milestone, but it is not yet a full OASIS-scale agent simulation engine. Future work should preserve the same core contracts while adding richer behavior execution.
+
+## Limitations of this review
+
+- This was a lightweight branch inspection, not a full security audit.
+- Review focused on the SocialSense foundation files, not the entire inherited OASIS repository.
+- Existing non-SocialSense files in the repository contain references to OpenAI keys/placeholders and scraping-related dependencies; those were treated as pre-existing/upstream context unless referenced by SocialSense files.
+- The new SocialSense files are untracked in the current working tree, so review evidence is based on direct file inspection and test execution rather than a tracked diff.
+- No external network access, real platform API calls, or credential validation was performed or needed.
+
+## Final verdict
+
+APPROVED
+
+The SocialSense Core Foundation meets the requested architecture and safety criteria for this milestone: modular core, platform-agnostic abstractions, separated presets, optional CivicSense adapter without hard dependency, no live credentials/APIs/scraping in the SocialSense foundation, and clear tests/examples/docs backed by passing lightweight tests.

--- a/docs/socialsense/INTEGRATION_PLAN_FOR_3C_SIMULATOR.md
+++ b/docs/socialsense/INTEGRATION_PLAN_FOR_3C_SIMULATOR.md
@@ -1,0 +1,16 @@
+# Integration Plan for 3C Marketing Simulator
+
+3C can integrate later through `socialsense_core.adapters.threec_marketing_adapter`.
+
+## Interfaces
+
+- `simulate_campaign_response(campaign_message, product_context, audience_profile, platform_mix, runtime_mode="research")`
+- `simulate_brand_sentiment(brand_message, audience_profile, platform_mix, runtime_mode="research")`
+- `simulate_social_commerce_response(offer_message, product_context, audience_profile, platform_mix, runtime_mode="research")`
+
+## Later integration steps
+
+1. Map product/category/offer context into content metadata.
+2. Use Facebook/TikTok/YouTube/LINE presets for Thai-first campaigns.
+3. Extend deterministic heuristics with segment-specific response curves.
+4. Add executive charts and ROI-oriented summary metrics downstream.

--- a/docs/socialsense/INTEGRATION_PLAN_FOR_CIVICSENSE.md
+++ b/docs/socialsense/INTEGRATION_PLAN_FOR_CIVICSENSE.md
@@ -1,0 +1,17 @@
+# Integration Plan for CivicSense
+
+CivicSense can integrate later through `socialsense_core.adapters.civicsense_adapter`.
+
+## Interfaces
+
+- `simulate_public_opinion(message, audience_profile, platform_mix, scenario_context, runtime_mode="research")`
+- `simulate_crisis_response(crisis_message, audience_profile, platform_mix, scenario_context, runtime_mode="research")`
+- `simulate_policy_message_diffusion(policy_message, audience_profile, platform_mix, scenario_context, runtime_mode="research")`
+
+## Later integration steps
+
+1. Translate CivicSense audience groups into `SocialActor` inputs.
+2. Translate messages/scenario context into `SocialContent`.
+3. Select platform presets using Thai-first defaults.
+4. Enforce CivicSense production policy in the adapter/downstream layer.
+5. Surface provenance labels and simulation disclaimers in UI/PDF exports.

--- a/docs/socialsense/OASIS_MAPPING_STRATEGY.md
+++ b/docs/socialsense/OASIS_MAPPING_STRATEGY.md
@@ -1,0 +1,20 @@
+# OASIS Mapping Strategy
+
+OASIS is used as a research base and accelerator. SocialSense maps OASIS concepts into platform-agnostic behavior modules.
+
+## Map, do not copy
+
+- Copying OASIS `Platform` would import runtime, SQLite schema, channel loop, and dependency assumptions.
+- Mapping OASIS concepts preserves the useful design vocabulary while keeping SocialSense modular.
+
+## Twitter/X
+
+OASIS Twitter-like `CREATE_POST`, `LIKE_POST`, `REPOST`, `QUOTE_POST`, `FOLLOW`, `TREND`, and `REFRESH` map to Public Feed, Information Diffusion, Recommendation / Discovery, and Opinion Formation.
+
+## Reddit
+
+OASIS Reddit-like score display and hot-score recommendation map to Community Group, Public Feed, Trust / Credibility, and Information Diffusion.
+
+## Future work
+
+Optional OASIS compatibility adapters can translate OASIS traces into SocialSense event logs, but the MVP does not import OASIS code.

--- a/docs/socialsense/OASIS_RECON_REPORT.md
+++ b/docs/socialsense/OASIS_RECON_REPORT.md
@@ -1,0 +1,119 @@
+# OASIS Reconnaissance Report
+
+## Scope
+
+Repository: `https://github.com/camel-ai/oasis` cloned into `/Users/chawit/Projects/oasis-socialsense-research` on branch `feature/socialsense-core-foundation`.
+
+SocialSense uses OASIS as a research accelerator, not a direct product dependency. This report maps concepts that can inform a reusable, platform-agnostic simulation core.
+
+## Important files
+
+| Area | Files |
+|---|---|
+| Platform runtime | `oasis/social_platform/platform.py`, `oasis/social_platform/platform_utils.py`, `oasis/social_platform/channel.py` |
+| Platform typing | `oasis/social_platform/typing.py` |
+| Recommendation systems | `oasis/social_platform/recsys.py`, `oasis/social_platform/process_recsys_posts.py`, `oasis/social_platform/schema/rec.sql` |
+| Data model | `oasis/social_platform/schema/*.sql`, `oasis/social_platform/database.py` |
+| Agents | `oasis/agents/*`, tests under `test/agent/*` |
+| Graph/network examples | `visualization/dynamic_follow_network/*`, `visualization/twitter_simulation/*` |
+| Reddit analysis | `visualization/reddit_simulation_*/*`, `test/infra/recsys/test_update_rec_table_reddit.py` |
+| Tests/examples | `test/agent/*`, `test/infra/database/*`, `test/infra/recsys/*`, `examples/*` if present |
+| License | `LICENSE`, file headers using Apache License 2.0 |
+
+## Existing platform abstractions
+
+OASIS has a concrete `Platform` class that owns the runtime loop, SQLite database, channel messaging, clock, recommendation refreshes, and platform actions. `DefaultPlatformType` currently identifies `twitter` and `reddit`. SocialSense should not copy this as-is because it combines platform runtime, persistence, network channel, recommendation, and behavior into one concrete service.
+
+Reusable idea: represent platform operations as action messages and record traces/events.
+
+OASIS-specific part: SQLite schema, Camel agent integration, embedding models, runtime channel loop, Neo4j visualizations, and platform-specific implementation details.
+
+## Existing action types
+
+`oasis/social_platform/typing.py` defines `ActionType` values including `refresh`, `search_user`, `search_posts`, `create_post`, `like_post`, `dislike_post`, `follow`, `trend`, `repost`, `quote_post`, `create_comment`, `purchase_product`, `join_group`, `leave_group`, `send_to_group`, `create_group`, and `listen_from_group`.
+
+SocialSense maps these into behavior-level actions rather than copying platform names directly.
+
+## Existing simulation lifecycle
+
+1. Agents send `(agent_id, message, action)` through a `Channel`.
+2. `Platform.running()` receives the message.
+3. The string action is coerced into `ActionType`.
+4. The corresponding async method is called on `Platform` via `getattr`.
+5. The method updates SQLite tables and records trace rows.
+6. Recommendation refreshes update rec tables.
+7. Results are sent back through the channel.
+
+SocialSense MVP keeps only the deterministic event lifecycle: action in, event log out, signals computed.
+
+## Existing recommendation model
+
+OASIS includes `RecsysType` values `twitter`, `twhin-bert`, `reddit`, and `random`. Twitter-style recommendation can use embeddings/TwHIN; Reddit-style ranking uses a hot-score approach; random is a baseline. These are valuable research references but carry heavyweight dependencies (`torch`, `sentence-transformers`, model downloads) that are not appropriate for the SocialSense Core MVP.
+
+SocialSense MVP implements deterministic lightweight heuristics for recommendation, diffusion, opinion, and trust. Advanced OASIS-like recommenders can be added later as optional plugins.
+
+## Twitter/X mapping
+
+| OASIS concept | SocialSense behavior | SocialSense action |
+|---|---|---|
+| `CREATE_POST` | Public Feed | `post` |
+| `CREATE_COMMENT` | Public Feed | `comment` |
+| `LIKE_POST` | Public Feed / Opinion Formation | `react` |
+| `REPOST`, `QUOTE_POST` | Information Diffusion | `share` |
+| `FOLLOW` | Public Feed / Influencer Network | `follow` |
+| `SEARCH_POSTS` | Recommendation / Discovery | `search_topic` |
+| `TREND` | Recommendation / Discovery | `trend_topic` |
+| `REFRESH` | Public Feed / Recommendation | `refresh_feed` |
+
+## Reddit mapping
+
+| OASIS concept | SocialSense behavior | SocialSense action |
+|---|---|---|
+| `CREATE_POST` | Community Group | `post_topic` |
+| `CREATE_COMMENT` | Community Group | `reply` |
+| `LIKE_POST`/`DISLIKE_POST` | Trust / Credibility + Community Group | `react` with polarity metadata |
+| `SEARCH_POSTS` | Recommendation / Discovery | `search_topic` |
+| `TREND` | Information Diffusion | `trend_topic` |
+| `JOIN_GROUP`/community membership | Community Group | `join_group` |
+| Moderation/report flows | Community Group | `moderate` |
+
+## Extension points
+
+- Action registry: add actions independent of platforms.
+- Behavior module registry: add reusable behavior families.
+- Platform preset registry: map platforms to behavior modules and actions.
+- Simulation runner: swap deterministic runner for richer agent-based runner.
+- Recommendation heuristics: replace with learned/graph/embedding recommenders.
+- Governance hooks: downstream applications can enforce production policies.
+- Adapters: applications such as CivicSense and 3C can translate domain scenarios into SocialSense contexts.
+
+## Reuse strategy
+
+Reuse concepts, not runtime dependencies:
+
+1. Preserve Apache-2.0 notices where OASIS code is referenced or derived.
+2. Keep SocialSense Core platform-agnostic and behavior-driven.
+3. Treat Twitter/X and Reddit as presets over generic behavior modules.
+4. Avoid importing OASIS runtime code in the core MVP.
+5. Keep synthetic tests/examples and deterministic outputs.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| OASIS dependencies target Python `<3.12`; local host has Python 3.14 | SocialSense Core uses stdlib-only dataclasses for MVP tests. |
+| Heavy recommendation dependencies and model downloads | Keep as future optional plugins, not core. |
+| Platform-specific assumptions leaking into core | Registries and behavior modules are platform-agnostic. |
+| CivicSense policy restrictions hard-coded too early | Core exposes governance hooks only; downstream apps own policy boundaries. |
+| Misuse of research simulations as real platform claims | Provenance labels and simulation disclaimers in results/docs/examples. |
+| Live platform/API temptation | No API credentials, scraping, or real platform calls in MVP. |
+
+## Recommended implementation plan
+
+1. Add SocialSense Core package with typed entities and registries.
+2. Implement deterministic simulation runner and event log.
+3. Add behavior modules for public feed, groups, messaging, video, influencer, recommendation, diffusion, opinion, trust, commerce, and crisis spread.
+4. Add platform presets for X/Twitter, Reddit, LINE, Facebook, TikTok, and YouTube.
+5. Add adapter interfaces for CivicSense and 3C Marketing Simulator.
+6. Add synthetic examples and tests.
+7. Document research/production mode boundary and future roadmap.

--- a/docs/socialsense/PLATFORM_PRESETS.md
+++ b/docs/socialsense/PLATFORM_PRESETS.md
@@ -1,0 +1,18 @@
+# Platform Preset Model
+
+A platform preset is an optional mapping layer, not a hard dependency. It binds platform names to behavior modules, action subsets, recommendation signals, local context notes, and OASIS mapping references where applicable.
+
+## Initial presets
+
+| Preset | Behavior modules |
+|---|---|
+| X / Twitter | Public Feed, Recommendation / Discovery, Information Diffusion, Opinion Formation |
+| Reddit | Community Group, Public Feed, Trust / Credibility, Information Diffusion |
+| LINE | Private Messaging, Community Group, Trust / Credibility, Information Diffusion, Crisis Spread |
+| Facebook | Public Feed, Community Group, Influencer Network, Social Commerce, Crisis Spread |
+| TikTok | Short Video, Influencer Network, Recommendation / Discovery, Social Commerce, Opinion Formation |
+| YouTube | Long-form Video, Short Video, Influencer Network, Recommendation / Discovery, Trust / Credibility |
+
+## Thai context
+
+Tier 1: LINE, Facebook, TikTok, YouTube. Tier 2: Instagram, X/Twitter, Pantip. Tier 3: Threads, Discord, Lemon8, Bluesky, Messenger, Telegram, WhatsApp.

--- a/docs/socialsense/PLATFORM_PRESET_MODEL.md
+++ b/docs/socialsense/PLATFORM_PRESET_MODEL.md
@@ -1,0 +1,18 @@
+# Platform Preset Model
+
+A platform preset is an optional mapping layer, not a hard dependency. It binds platform names to behavior modules, action subsets, recommendation signals, local context notes, and OASIS mapping references where applicable.
+
+## Initial presets
+
+| Preset | Behavior modules |
+|---|---|
+| X / Twitter | Public Feed, Recommendation / Discovery, Information Diffusion, Opinion Formation |
+| Reddit | Community Group, Public Feed, Trust / Credibility, Information Diffusion |
+| LINE | Private Messaging, Community Group, Trust / Credibility, Information Diffusion, Crisis Spread |
+| Facebook | Public Feed, Community Group, Influencer Network, Social Commerce, Crisis Spread |
+| TikTok | Short Video, Influencer Network, Recommendation / Discovery, Social Commerce, Opinion Formation |
+| YouTube | Long-form Video, Short Video, Influencer Network, Recommendation / Discovery, Trust / Credibility |
+
+## Thai context
+
+Tier 1: LINE, Facebook, TikTok, YouTube. Tier 2: Instagram, X/Twitter, Pantip. Tier 3: Threads, Discord, Lemon8, Bluesky, Messenger, Telegram, WhatsApp.

--- a/docs/socialsense/QA_REPORT.md
+++ b/docs/socialsense/QA_REPORT.md
@@ -1,0 +1,221 @@
+# SocialSense Core Foundation QA Report
+
+Date: 2026-06-24
+Branch: feature/socialsense-core-foundation
+Working directory: /Users/chawit/Projects/oasis-socialsense-research
+Scope: Validate SocialSense Core tests and runnable examples only. No real platform APIs, credentials, scraping, or network were used.
+
+## Verdict
+
+PASS for the SocialSense Core Foundation acceptance criteria covering focused tests and runnable example smoke tests.
+
+The focused SocialSense test suite passed, and every SocialSense example demo executed successfully using synthetic/deterministic local data. The broader upstream OASIS test suite is not currently feasible in this environment without installing heavyweight/missing dependencies and possibly provisioning runtime services/API model backends; see limitations.
+
+## Acceptance Criteria Checked
+
+- `python3 -m pytest tests/socialsense -q` passes.
+- SocialSense example demos are runnable as local smoke tests.
+- Examples use synthetic/mock data and do not call real platform APIs, credentials, scraping, or network.
+- Existing OASIS test feasibility is documented separately from SocialSense Core validation.
+- QA changes are limited to this report file: `docs/socialsense/QA_REPORT.md`.
+
+## Environment
+
+Command:
+
+```bash
+python3 --version && python3 -m pytest --version
+```
+
+Result:
+
+```text
+Python 3.14.3
+pytest 9.0.3
+```
+
+Git branch command:
+
+```bash
+git branch --show-current
+```
+
+Result:
+
+```text
+feature/socialsense-core-foundation
+```
+
+## Focused SocialSense Tests
+
+Command:
+
+```bash
+python3 -m pytest tests/socialsense -q
+```
+
+Result:
+
+```text
+...............                                                          [100%]
+15 passed in 0.02s
+```
+
+Status: PASS
+
+Coverage observed from the test files under `tests/socialsense`:
+
+- Action registry
+- Behavior modules
+- Platform presets
+- Deterministic simulation runner
+- Event log
+- Runtime modes
+- Diffusion heuristics
+- Recommendation heuristics
+- Opinion update
+- CivicSense adapter
+- 3C adapter
+- Example module importability
+- Public core architecture/export contract
+
+## Runnable Example Smoke Tests
+
+Command:
+
+```bash
+for f in examples/socialsense_*_demo.py; do echo "===== $f ====="; python3 "$f"; done
+```
+
+Result summary:
+
+```text
+===== examples/socialsense_3c_adapter_demo.py =====
+input scenario: campaign response: mock consumer product
+platform mix: ['facebook', 'tiktok', 'youtube']
+actions simulated: ['post', 'discover_content', 'react', 'purchase_intent']
+event log: ['evt-0001', 'evt-0002', 'evt-0003', 'evt-0004']
+result summary: {'actor_count': 1, 'content_count': 1, 'platform_mix': ['facebook', 'tiktok', 'youtube'], 'action_counts': {'post': 1, 'discover_content': 1, 'react': 1, 'purchase_intent': 1}, 'governance_hooks_available': True, 'simulation_disclaimer': 'Synthetic deterministic simulation; no live platform access or real PII.'}
+provenance labels: ['synthetic', 'human_authored_scenario']
+runtime mode: research
+
+===== examples/socialsense_civicsense_adapter_demo.py =====
+input scenario: public opinion: demo only; no live platform data
+platform mix: ['line', 'facebook', 'tiktok']
+actions simulated: ['post', 'react', 'share', 'update_sentiment']
+event log: ['evt-0001', 'evt-0002', 'evt-0003', 'evt-0004']
+result summary: {'actor_count': 1, 'content_count': 1, 'platform_mix': ['line', 'facebook', 'tiktok'], 'action_counts': {'post': 1, 'react': 1, 'share': 1, 'update_sentiment': 1}, 'governance_hooks_available': True, 'simulation_disclaimer': 'Synthetic deterministic simulation; no live platform access or real PII.'}
+provenance labels: ['synthetic', 'human_authored_scenario']
+runtime mode: research
+
+===== examples/socialsense_facebook_group_demo.py =====
+input scenario: Facebook group discussion with marketplace-adjacent sharing
+platform mix: ['facebook']
+actions simulated: ['post_topic', 'comment', 'react', 'share', 'view_product']
+event count: 5
+runtime mode: research
+
+===== examples/socialsense_line_group_demo.py =====
+input scenario: LINE family/workplace group forwards a public-health update
+platform mix: ['line']
+actions simulated: ['create_chat_group', 'send_message', 'forward_message', 'listen_group', 'correction_spread']
+event count: 5
+runtime mode: research
+
+===== examples/socialsense_thai_platform_mix_demo.py =====
+input scenario: Thai platform mix: LINE, Facebook, TikTok, YouTube
+platform mix: ['line', 'facebook', 'tiktok', 'youtube']
+actions simulated: ['send_message', 'post', 'watch_video', 'share_video', 'watch_long_video', 'update_sentiment']
+event count: 6
+runtime mode: research
+
+===== examples/socialsense_tiktok_short_video_demo.py =====
+input scenario: TikTok short-video discovery and creator affinity
+platform mix: ['tiktok']
+actions simulated: ['publish_video', 'watch_video', 'like_video', 'share_video', 'purchase_intent']
+event count: 5
+runtime mode: research
+
+===== examples/socialsense_youtube_video_demo.py =====
+input scenario: YouTube long-form explanation plus trust evaluation
+platform mix: ['youtube']
+actions simulated: ['publish_long_video', 'watch_long_video', 'subscribe_channel', 'comment_video', 'evaluate_source_trust']
+event count: 5
+runtime mode: research
+```
+
+Status: PASS
+
+Notes:
+
+- All seven SocialSense demos completed with exit code 0.
+- Outputs consistently include synthetic/mock provenance or deterministic simulation disclaimers.
+- The smoke tests covered adapter demos for 3C and CivicSense plus LINE, Facebook, TikTok, YouTube, and Thai mixed-platform examples.
+
+## No Real API / Network / Scraping Check
+
+Inspected SocialSense example files for direct network/API/scraping indicators using a focused content search over `examples/socialsense_*_demo.py`.
+
+Command:
+
+```bash
+# Implemented with repository search over examples/socialsense_*_demo.py for:
+# requests|http|api|credential|token|scrap|network|urllib|aiohttp|OpenAI|platform
+```
+
+Result:
+
+- Matches were local scenario/platform strings and synthetic demo content only.
+- No imports or calls to `requests`, `urllib`, `aiohttp`, OpenAI clients, platform APIs, credentials, tokens, scraping, or network access were found in the SocialSense demo files.
+
+Status: PASS
+
+## Existing OASIS Tests Feasibility
+
+A broad repository test command was attempted only to assess feasibility of the existing upstream OASIS suite; it is not part of the SocialSense Core acceptance gate.
+
+Command:
+
+```bash
+python3 -m pytest -q
+```
+
+Result:
+
+```text
+ERROR test/agent/test_action_docstring.py - ModuleNotFoundError: No module named 'camel'
+ERROR test/agent/test_agent_custom_prompt.py - ModuleNotFoundError: No module named 'camel'
+ERROR test/agent/test_agent_generator.py - ModuleNotFoundError: No module named 'camel'
+ERROR test/agent/test_agent_graph.py - ModuleNotFoundError: No module named 'torch'
+ERROR test/agent/test_agent_tools.py - ModuleNotFoundError: No module named 'camel'
+ERROR test/agent/test_interview_action.py - ModuleNotFoundError: No module named 'camel'
+ERROR test/agent/test_multi_agent_signup_create.py - ModuleNotFoundError: No module named 'camel'
+ERROR test/agent/test_twitter_user_agent_all_actions.py - ModuleNotFoundError: No module named 'camel'
+ERROR multiple test/infra/database/* modules - ModuleNotFoundError: No module named 'camel'
+ERROR multiple test/infra/recsys/* modules - ModuleNotFoundError: No module named 'camel'
+Interrupted: 28 errors during collection
+28 errors in 0.54s
+```
+
+Status: NOT FEASIBLE in the current local QA environment.
+
+Reason:
+
+- The upstream OASIS tests require dependencies that are not installed in this environment, especially `camel` and `torch`.
+- Several upstream OASIS examples/docs also reference external LLM/API/server setup patterns. Running those would violate this QA scope unless separately provisioned with approved local/offline substitutes.
+- I did not install dependencies, use credentials, call live APIs, scrape platforms, or make network calls.
+
+Impact on SocialSense verdict:
+
+- This does not block SocialSense Core Foundation acceptance because the requested focused suite `tests/socialsense` passes and the SocialSense demos run locally without external services.
+
+## Limitations
+
+- QA did not validate performance, packaging, or installation from a clean virtual environment.
+- QA did not run real OASIS simulations, live social-platform integrations, LLM-backed simulations, or networked services.
+- QA did not use real user/platform data or credentials.
+- The repository currently shows many SocialSense files as untracked on this branch; this report validates the working tree as provided.
+
+## Final Recommendation
+
+Accept the SocialSense Core Foundation test/example criteria for this branch, with the explicit caveat that upstream OASIS full-suite validation should be handled as a separate environment task with declared dependencies, offline-safe configuration, and no live platform/API calls unless explicitly approved.

--- a/docs/socialsense/QUICKSTART.md
+++ b/docs/socialsense/QUICKSTART.md
@@ -1,0 +1,26 @@
+# Quickstart
+
+```bash
+cd /Users/chawit/Projects/oasis-socialsense-research
+python3 -m pytest tests/socialsense -q
+python3 examples/socialsense_thai_platform_mix_demo.py
+```
+
+Minimal usage:
+
+```python
+from socialsense_core import SocialAction, SocialActor, SocialContent, RuntimeMode
+from socialsense_core.simulation.context import SimulationContext
+from socialsense_core.simulation.runner import run_simulation
+
+context = SimulationContext.build(
+    scenario="Synthetic LINE/Facebook campaign",
+    actors=[SocialActor("a1", "Synthetic audience")],
+    content=[SocialContent("c1", "Synthetic message")],
+    platform_mix=["line", "facebook"],
+    actions=[SocialAction("post", "a1", "c1"), SocialAction("share", "a1", "c1")],
+    runtime_mode=RuntimeMode.RESEARCH,
+)
+result = run_simulation(context)
+print(result.summary)
+```

--- a/docs/socialsense/README.md
+++ b/docs/socialsense/README.md
@@ -1,0 +1,12 @@
+# SocialSense Architecture Docs
+
+This directory contains the SocialSense research and architecture baseline for the OASIS-derived simulation work.
+
+## Documents
+
+- `OASIS_RECON_REPORT.md` — Phase 1 reconnaissance of OASIS architecture, reusable seams, action types, lifecycle, recommendation models, risks, and integration strategy.
+- `SOCIALSENSE_CORE_ARCHITECTURE.md` — Phase 2 core architecture baseline defining SocialSense abstractions, behavior modules, platform presets, signal families, simulation contracts, and governance hooks.
+
+## Architecture stance
+
+SocialSense is research-first and behavior-driven. Core modules should stay reusable across verticals by using synthetic/default provenance, explicit runtime mode, typed signal outputs, and caller-supplied governance hooks instead of hard-coded project restrictions.

--- a/docs/socialsense/RESEARCH_MODE_AND_PRODUCTION_MODE.md
+++ b/docs/socialsense/RESEARCH_MODE_AND_PRODUCTION_MODE.md
@@ -1,0 +1,17 @@
+# Research Mode and Production Mode
+
+## Research Mode
+
+Research Mode allows broad modeling of influence propagation, persuasion dynamics, information diffusion, social contagion, opinion formation, recommendation dynamics, marketing response, and crisis response. It is for synthetic simulation and research exploration.
+
+## Production Mode
+
+Production Mode exists as a runtime marker and governance-hook surface. Downstream applications may enforce their own policy boundaries. The core intentionally does **not** hard-code project-specific policy restrictions because SocialSense must remain reusable for civic, commercial, public-opinion, crisis, and consumer research applications.
+
+## Governance hooks
+
+`SimulationContext.governance_hooks` can carry downstream validators, policy metadata, labels, or export restrictions. The deterministic MVP only exposes whether hooks are available; downstream apps enforce them.
+
+## Disclaimers
+
+All examples and tests use synthetic/mock data. No real PII, platform credentials, live scraping, or hidden external calls are required.

--- a/docs/socialsense/RESEARCH_USE_CASES.md
+++ b/docs/socialsense/RESEARCH_USE_CASES.md
@@ -1,0 +1,12 @@
+# Research Use Cases
+
+SocialSense Core can model synthetic scenarios for:
+
+- Information diffusion and rumor propagation.
+- Influence networks and creator endorsement.
+- Recommendation dynamics and discovery.
+- Opinion formation, sentiment, belief, and intent changes.
+- Marketing communication and consumer response.
+- Political/public communication research with downstream governance.
+- Crisis communication and correction spread.
+- Social commerce response.

--- a/docs/socialsense/ROADMAP.md
+++ b/docs/socialsense/ROADMAP.md
@@ -1,0 +1,12 @@
+# Roadmap
+
+## Next PRs
+
+1. Optional OASIS trace importer for offline traces.
+2. Graph-based diffusion model plugin.
+3. Configurable recommendation models with no default external services.
+4. Richer Thai platform presets: Instagram, Pantip, Threads, Lemon8.
+5. Visualization helpers for executive dashboards and PDFs.
+6. Downstream CivicSense integration PR.
+7. Downstream 3C Marketing Simulator integration PR.
+8. Governance plugin contracts for production deployments.

--- a/docs/socialsense/SAFETY_REVIEW.md
+++ b/docs/socialsense/SAFETY_REVIEW.md
@@ -1,0 +1,131 @@
+# SocialSense Core Foundation Safety Review
+
+Verdict: APPROVED
+
+Review scope: current branch `feature/socialsense-core-foundation` in `/Users/chawit/Projects/oasis-socialsense-research`, focused on the SocialSense Core Foundation files under `socialsense_core/`, `tests/socialsense/`, `examples/socialsense_*_demo.py`, and `docs/socialsense/`.
+
+## Acceptance criteria reviewed
+
+- Research Mode labeling is explicit.
+- Production Mode hooks exist without implying production enforcement in the reusable core.
+- Examples are synthetic/mock and do not require real users or real PII.
+- SocialSense Core does not require live platform access.
+- No hidden external calls are present in the inspected SocialSense Core/Foundation scope.
+- Provenance labels are present in core result/event structures and examples.
+- Simulation disclaimers are surfaced in results/docs/examples.
+
+## Evidence
+
+### Branch and working tree
+
+- Current branch: `feature/socialsense-core-foundation`.
+- SocialSense Core Foundation files are currently untracked in this working tree, so this review is based on direct inspection and execution rather than a tracked diff.
+
+### Research Mode labeling
+
+- `socialsense_core/governance/modes.py` defines:
+  - `RuntimeMode.RESEARCH = "research"`
+  - `RuntimeMode.PRODUCTION = "production"`
+  - `normalize_runtime_mode(...)`
+- `socialsense_core/simulation/context.py` defaults `SimulationContext.runtime_mode` to `RuntimeMode.RESEARCH`.
+- `docs/socialsense/RESEARCH_MODE_AND_PRODUCTION_MODE.md` describes Research Mode as synthetic simulation and research exploration.
+- Demo execution showed `runtime mode: research` for SocialSense examples.
+
+### Production Mode hooks
+
+- `SimulationContext` exposes `governance_hooks: Mapping[str, Any]`.
+- `socialsense_core/simulation/runner.py` reports `governance_hooks_available` in result summaries.
+- `tests/socialsense/test_runtime_modes.py` verifies production mode is accepted and governance hook availability is true when hooks are supplied.
+- Production Mode is appropriately documented as a runtime marker and hook surface; downstream applications own enforcement.
+
+### Synthetic examples and no real PII required
+
+- SocialSense examples use synthetic actors/content such as `Synthetic Thai participant`, `Synthetic audience`, and synthetic messages.
+- `docs/socialsense/RESEARCH_MODE_AND_PRODUCTION_MODE.md` states: "All examples and tests use synthetic/mock data. No real PII, platform credentials, live scraping, or hidden external calls are required."
+- `socialsense_core/simulation/runner.py` emits the disclaimer: `Synthetic deterministic simulation; no live platform access or real PII.`
+- Executed examples printed that disclaimer in result summaries.
+
+### No live platform access / no hidden external calls in SocialSense Foundation
+
+Targeted inspection of `socialsense_core/` found no matches for network/client/secret patterns including:
+
+- `requests`, `httpx`, `aiohttp`, `urllib`, `socket`
+- `selenium`, `playwright`, `scrap`, `crawl`
+- `os.environ`, `getenv`
+- `api_key`, `secret`, `token`, `password`
+- `openai`, `anthropic`, `deepseek`
+- `http://` / `https://`
+
+Targeted inspection of `examples/socialsense_*_demo.py` found no matches for the same classes of live network, browser automation, scraping, credential, or external model/API usage.
+
+Important scope note: the inherited upstream OASIS repository includes older non-SocialSense examples and docs that reference OpenAI, DeepSeek, tokens, and API/server URLs. Those were not introduced by, imported by, or required for the SocialSense Core Foundation files reviewed here. They remain a repository-level safety consideration but are out of scope for this Foundation verdict.
+
+### Provenance labels
+
+- `socialsense_core/governance/labels.py` defines provenance labels:
+  - `synthetic`
+  - `mock`
+  - `anonymized`
+  - `oasis_derived_mapping`
+  - `human_authored_scenario`
+- `SimulationContext` carries `provenance_labels`, defaulting to `synthetic`.
+- `DeterministicSimulationRunner` copies provenance labels into every `SocialEvent` and into `SimulationResult`.
+- Demo execution printed provenance labels such as `['synthetic', 'mock']` and `['synthetic', 'human_authored_scenario']`.
+
+### Simulation disclaimers
+
+- `DeterministicSimulationRunner` includes `simulation_disclaimer` in result summaries.
+- `tests/socialsense/test_core_architecture.py` asserts the exact disclaimer: `Synthetic deterministic simulation; no live platform access or real PII.`
+- `docs/socialsense/RESEARCH_MODE_AND_PRODUCTION_MODE.md` includes a Disclaimers section.
+- Example runs printed the disclaimer in result summaries.
+
+## Commands executed
+
+```text
+git status --short && git branch --show-current && git diff --stat
+python3 -m pytest tests/socialsense -q
+python3 examples/socialsense_thai_platform_mix_demo.py && python3 examples/socialsense_civicsense_adapter_demo.py
+```
+
+Observed test result:
+
+```text
+15 passed in 0.03s
+```
+
+Observed example evidence included:
+
+```text
+result summary: {... 'simulation_disclaimer': 'Synthetic deterministic simulation; no live platform access or real PII.'}
+provenance labels: ['synthetic', 'mock']
+runtime mode: research
+```
+
+and:
+
+```text
+result summary: {... 'governance_hooks_available': True, 'simulation_disclaimer': 'Synthetic deterministic simulation; no live platform access or real PII.'}
+provenance labels: ['synthetic', 'human_authored_scenario']
+runtime mode: research
+```
+
+## Risks
+
+1. Production Mode is currently a marker and hook surface only. It does not enforce downstream policy, export restrictions, PII checks, or platform-specific safety rules inside the reusable core.
+2. The foundation accepts free-form scenario/message strings from callers. Downstream applications must prevent real PII ingestion if they expose this to users or imported datasets.
+3. Platform presets use names of real platforms such as LINE, Facebook, TikTok, YouTube, X/Twitter, and Reddit. The current implementation treats them as simulation presets only, but UI/docs should keep showing disclaimers so users do not mistake outputs for live platform claims.
+4. The broader inherited OASIS repository contains non-SocialSense examples with external model/API references. They should remain separated from SocialSense Foundation quickstarts and CI paths unless explicitly reviewed.
+5. The deterministic runner is intentionally lightweight. Its outputs should be labeled as synthetic heuristic simulations, not empirical predictions or measured social-platform behavior.
+
+## Limitations
+
+- Review was limited to SocialSense Foundation scope, not a full audit of the entire inherited OASIS repository.
+- No external network monitoring or sandbox packet capture was performed; evidence is from static inspection and local execution of SocialSense tests/examples.
+- No production deployment path, UI rendering path, PDF export path, or downstream CivicSense/3C enforcement layer was reviewed.
+- Because the SocialSense Foundation files are untracked, future diffs should be reviewed again once staged or committed.
+
+## Final verdict
+
+APPROVED for the SocialSense Core Foundation milestone.
+
+The reviewed SocialSense Foundation satisfies the requested safety criteria for Research Mode labeling, Production Mode hooks, synthetic examples, no real PII requirement, no live platform access requirement, no hidden external calls in the SocialSense scope, provenance labels, and simulation disclaimers. Downstream applications must still enforce production policy boundaries and PII controls before any real-world deployment.

--- a/docs/socialsense/SOCIALSENSE_CORE_ARCHITECTURE.md
+++ b/docs/socialsense/SOCIALSENSE_CORE_ARCHITECTURE.md
@@ -1,0 +1,414 @@
+# SocialSense Core Architecture
+
+Date: 2026-06-24
+Status: Phase 2 architecture baseline
+Scope: research-first SocialSense core abstractions, behavior modules, platform presets, simulation contracts, signals, and governance seams. This document defines reusable architecture only; it does not add project-specific hard-coded policy restrictions or live-platform integrations.
+
+## Design goals
+
+SocialSense is a reusable simulation layer on top of OASIS concepts. It keeps OASIS's useful agent/action/platform/recommendation separation while making the domain model explicit enough to support multiple social surfaces: public feeds, community groups, private messaging, short video, long-form video, influencer networks, recommendation discovery, information diffusion, opinion formation, trust and credibility, social commerce, and crisis spread.
+
+The core must remain:
+
+1. Research-first: deterministic and synthetic by default, suitable for experiments, reproducible benchmarks, and scenario analysis.
+2. Behavior-driven: simulations are composed from behavior modules and platform presets rather than from one hard-coded social network.
+3. Governable: runtime mode, provenance labels, event metadata, and optional governance hooks are present at core boundaries.
+4. Production-aware but policy-neutral: production runtime can attach review, audit, safety, privacy, or compliance hooks without embedding one project's restrictions in reusable core code.
+5. Adapter-friendly: CivicSense, 3C marketing, or future verticals should map their own scenarios onto the same abstractions without changing the core.
+
+## Architecture layers
+
+```
+Scenario / vertical adapter
+        |
+        v
+SimulationContext -----> DeterministicSimulationRunner -----> SimulationResult
+        |                         |                                  |
+        |                         v                                  v
+        |                 SocialEvent / EventLog             RecommendationSignal
+        |                         |                          DiffusionSignal
+        v                         |                          OpinionSignal
+SocialActor, SocialContent,       |                          TrustSignal
+SocialAction, SocialPlatformPreset|
+        |                         v
+        +-----------------> behavior/action registries
+```
+
+## Core abstractions
+
+### SocialAction
+
+Source: `socialsense_core/actions/types.py`
+
+`SocialAction` is the normalized request shape for behavior execution. It is deliberately platform-neutral.
+
+Fields:
+
+- `action_type`: canonical action verb, for example `post`, `watch_video`, `forward_message`, `trend_topic`, `evaluate_source_trust`.
+- `actor_id`: actor performing the action.
+- `content_id`: optional content being acted on.
+- `target_id`: optional target actor, group, channel, source, or entity.
+- `platform`: optional platform preset key such as `x_twitter`, `reddit`, `line`, `facebook`, `tiktok`, or `youtube`.
+- `payload`: arbitrary structured parameters for the behavior module or adapter.
+
+Responsibilities:
+
+- Provide one action envelope for manual, deterministic, and future LLM-driven simulation flows.
+- Keep OASIS action mappings outside adapters when possible.
+- Preserve extensibility through `payload` without requiring schema changes for every experiment.
+
+Non-goals:
+
+- It is not a live API call.
+- It does not enforce project-specific policy decisions.
+
+### SocialEvent
+
+Source: `socialsense_core/events/types.py`
+
+`SocialEvent` records an executed `SocialAction` plus simulation metadata.
+
+Fields:
+
+- `event_id`: deterministic or runtime-generated event identifier.
+- `action`: the normalized `SocialAction` that was executed.
+- `timestamp`: event time, defaulting to UTC now but deterministic runners may override it.
+- `provenance`: tuple of `ProvenanceLabel` values.
+- `metadata`: runtime-specific annotations such as platform, runtime mode, policy hook IDs, trace references, or audit handles.
+
+Responsibilities:
+
+- Build an auditable event stream from synthetic action execution.
+- Preserve provenance and governance-relevant metadata at the event boundary.
+- Feed event summaries, diffusion metrics, trust updates, and downstream adapters.
+
+### SocialActor
+
+Source: `socialsense_core/personas/types.py`
+
+`SocialActor` is the platform-neutral synthetic persona state.
+
+Fields:
+
+- `actor_id`: stable actor identifier.
+- `display_name`: human-readable label for logs and scenario authoring.
+- `traits`: structured persona, demographic, behavioral, or cohort attributes.
+- `trust_score`: baseline trust/credibility score.
+- `sentiment`: current sentiment state.
+- `belief`: current belief state.
+- `intent`: current intent state.
+
+Responsibilities:
+
+- Support opinion, trust, recommendation, and diffusion behavior modules.
+- Avoid storing raw PII in core experiments unless a governed adapter explicitly provides sanitized fields.
+
+### SocialContent
+
+Source: `socialsense_core/personas/types.py`
+
+`SocialContent` is the platform-neutral content object acted on by agents and recommendation systems.
+
+Fields:
+
+- `content_id`: stable content identifier.
+- `text`: text or summary representation for deterministic simulations.
+- `author_id`: optional author actor.
+- `topic`: optional scenario topic/category.
+- `metadata`: structured content properties such as media type, source, language, channel, product, or moderation labels.
+
+Responsibilities:
+
+- Let behavior modules reason over content without depending on one platform database schema.
+- Carry enough metadata for future multimodal or vertical-specific adapters.
+
+### SocialPlatformPreset
+
+Source: `socialsense_core/platforms/base.py`
+
+`SocialPlatformPreset` describes a social surface as a composition of behavior modules and available actions.
+
+Fields:
+
+- `key`: stable preset key.
+- `display_name`: readable platform label.
+- `behavior_modules`: behavior module keys used by this platform.
+- `actions`: normalized actions available on the platform.
+- `recommendation_signals`: feature names or signal families used by platform-specific discovery.
+- `context_notes`: explanatory notes for scenario builders and adapters.
+- `oasis_mapping`: optional map from OASIS `ActionType` names to SocialSense action verbs.
+
+Default presets:
+
+- `x_twitter`: public feed, recommendation, information diffusion, opinion formation.
+- `reddit`: community group, public feed, trust/credibility, information diffusion.
+- `line`: private messaging, community group, trust/credibility, information diffusion, crisis spread.
+- `facebook`: public feed, community group, influencer network, social commerce, crisis spread.
+- `tiktok`: short video, influencer network, recommendation, social commerce, opinion formation.
+- `youtube`: long-form video, short video, influencer network, recommendation, trust/credibility.
+
+Responsibilities:
+
+- Keep platform differences data-driven.
+- Make OASIS-to-SocialSense migration explicit through `oasis_mapping`.
+- Allow new platform surfaces without changing simulation runners.
+
+### SocialBehaviorModule
+
+Source: `socialsense_core/behaviors/types.py`
+
+`SocialBehaviorModule` groups actions and expected signal families for a reusable social behavior.
+
+Fields:
+
+- `key`: stable module key.
+- `name`: human-readable name.
+- `actions`: normalized action verbs owned by the module.
+- `description`: concise behavioral purpose.
+- `signals`: signal class names emitted or consumed by the module.
+- `metadata`: extra descriptors for scenario authors.
+
+Default modules:
+
+- `public_feed`
+- `community_group`
+- `private_messaging`
+- `short_video`
+- `long_form_video`
+- `influencer_network`
+- `recommendation_discovery`
+- `information_diffusion`
+- `opinion_formation`
+- `trust_credibility`
+- `social_commerce`
+- `crisis_spread`
+
+Responsibilities:
+
+- Make experiments behavior-driven rather than platform-driven.
+- Provide a registry boundary for adding/removing capabilities.
+- Keep action sets auditable for tests and governance review.
+
+### SimulationContext
+
+Source: `socialsense_core/simulation/context.py`
+
+`SimulationContext` is the immutable input contract for a simulation run.
+
+Fields:
+
+- `scenario`: scenario name or narrative identifier.
+- `actors`: tuple of `SocialActor` inputs.
+- `content`: tuple of `SocialContent` inputs.
+- `platform_mix`: tuple of platform preset keys participating in the scenario.
+- `actions`: tuple of `SocialAction` steps to execute.
+- `runtime_mode`: `RuntimeMode.RESEARCH` by default, optionally `RuntimeMode.PRODUCTION`.
+- `provenance_labels`: tuple of `ProvenanceLabel` values, synthetic by default.
+- `governance_hooks`: optional hook configuration for runtime policy, audit, privacy, review, or compliance systems.
+
+Responsibilities:
+
+- Carry all data required for deterministic simulation.
+- Keep runtime mode and provenance explicit.
+- Provide a single adapter boundary for vertical products.
+
+### SimulationResult
+
+Source: `socialsense_core/simulation/result.py`
+
+`SimulationResult` is the immutable output contract from a simulation run.
+
+Fields:
+
+- `scenario`: scenario identifier copied from context.
+- `runtime_mode`: runtime mode used.
+- `event_log`: ordered `EventLog` of `SocialEvent` records.
+- `recommendation_signals`: tuple of `RecommendationSignal` outputs.
+- `diffusion_signals`: tuple of `DiffusionSignal` outputs.
+- `opinion_signals`: tuple of `OpinionSignal` outputs.
+- `trust_signals`: tuple of `TrustSignal` outputs.
+- `provenance_labels`: provenance labels applied to the run.
+- `summary`: structured aggregate metrics and governance notes.
+
+Responsibilities:
+
+- Separate raw event evidence from summarized metrics.
+- Expose model outputs in typed signal families.
+- Preserve provenance for downstream reports.
+
+### RecommendationSignal
+
+Source: `socialsense_core/recommendation/base.py`
+
+`RecommendationSignal` describes content-ranking or discovery output.
+
+Fields:
+
+- `content_id`: content being recommended or ranked.
+- `score`: numeric relevance/priority score.
+- `reason`: explanation suitable for research reports and audit trails.
+
+### DiffusionSignal
+
+Source: `socialsense_core/recommendation/base.py`
+
+`DiffusionSignal` describes spread dynamics for content.
+
+Fields:
+
+- `content_id`: content being propagated.
+- `reach`: estimated audience exposure.
+- `velocity`: estimated spread speed.
+- `reason`: explanation of the heuristic or model behavior.
+
+### OpinionSignal
+
+Source: `socialsense_core/recommendation/base.py`
+
+`OpinionSignal` describes actor-level opinion state changes.
+
+Fields:
+
+- `actor_id`: actor affected by an event or content exposure.
+- `sentiment_delta`: change in affective sentiment.
+- `belief_delta`: change in belief alignment.
+- `intent_delta`: change in behavioral intent.
+- `reason`: explanation of the update.
+
+### TrustSignal
+
+Source: `socialsense_core/recommendation/base.py`
+
+`TrustSignal` describes actor-level trust or credibility changes.
+
+Fields:
+
+- `actor_id`: actor whose trust state changes.
+- `trust_delta`: positive or negative trust adjustment.
+- `reason`: explanation of source, content, or interaction effect.
+
+### ProvenanceLabel
+
+Source: `socialsense_core/governance/labels.py`
+
+`ProvenanceLabel` marks where simulation data or mappings came from.
+
+Current values:
+
+- `SYNTHETIC`: generated test/scenario data.
+- `MOCK`: mock data for demos or tests.
+- `ANONYMIZED`: sanitized historical or empirical data, if future governance allows it.
+- `OASIS_DERIVED_MAPPING`: derived from OASIS action/platform concepts.
+- `HUMAN_AUTHORED_SCENARIO`: authored scenario input.
+
+Responsibilities:
+
+- Keep data lineage visible in context, events, and results.
+- Support future compliance gates without forcing a specific policy into core logic.
+
+### RuntimeMode
+
+Source: `socialsense_core/governance/modes.py`
+
+`RuntimeMode` describes the intended operational posture.
+
+Current values:
+
+- `RESEARCH`: default synthetic/offline research mode.
+- `PRODUCTION`: production-aware mode where governance hooks should be attached by the caller.
+
+Responsibilities:
+
+- Let runners and adapters branch on operational posture.
+- Signal that production runs need attached hooks, review, audit, privacy controls, and monitoring from the host application.
+- Avoid embedding project-specific restrictions in reusable core modules.
+
+## Behavior catalog
+
+| Module | Purpose | Example actions | Signals |
+| --- | --- | --- | --- |
+| `public_feed` | Public timeline and engagement behavior | `post`, `comment`, `react`, `share`, `follow`, `refresh_feed` | Recommendation, Diffusion, Opinion |
+| `community_group` | Group/community posting, replies, moderation | `create_group`, `join_group`, `post_topic`, `reply`, `moderate` | Diffusion, Trust |
+| `private_messaging` | Direct and group messaging | `send_message`, `reply_message`, `forward_message`, `listen_group` | Diffusion, Trust |
+| `short_video` | Short-form video discovery and creator interactions | `publish_video`, `watch_video`, `skip_video`, `like_video`, `follow_creator` | Recommendation, Opinion |
+| `long_form_video` | Channel/subscription and long-form consumption | `publish_long_video`, `watch_long_video`, `subscribe_channel` | Recommendation, Trust |
+| `influencer_network` | Creator/influencer trust and amplification | `follow_influencer`, `trust_influencer`, `amplify_content` | Trust, Diffusion |
+| `recommendation_discovery` | Feed ranking, search, trends, discovery | `discover_content`, `rank_feed`, `search_topic`, `trend_topic` | RecommendationSignal |
+| `information_diffusion` | Exposure, propagation, attention decay | `expose_content`, `propagate_content`, `decay_attention` | DiffusionSignal |
+| `opinion_formation` | Sentiment, belief, intent transitions | `update_sentiment`, `update_belief`, `update_intent` | OpinionSignal |
+| `trust_credibility` | Source trust and credibility evaluation | `evaluate_source_trust`, `update_trust_score` | TrustSignal |
+| `social_commerce` | Product interest and social proof | `view_product`, `ask_for_review`, `purchase_intent`, `share_deal` | Recommendation, Opinion |
+| `crisis_spread` | Alerts, rumors, official response, corrections | `crisis_alert`, `rumor_spread`, `official_response`, `correction_spread` | Diffusion, Trust |
+
+## OASIS reuse strategy
+
+Phase 1 reconnaissance found that OASIS is most reusable as an offline synthetic interaction engine and reference schema, not as a live platform connector. SocialSense should reuse these OASIS ideas:
+
+- Agent/action/platform separation.
+- Channel-mediated action dispatch.
+- SQLite-backed event traces for reproducibility.
+- Recommendation table refresh concepts.
+- Twitter/X and Reddit action mappings as migration examples.
+- Synthetic simulation lifecycle: build agents, reset, step, close.
+
+SocialSense should not copy OASIS platform assumptions directly into new modules. Instead, `SocialPlatformPreset.oasis_mapping` records the mapping where useful, and behavior modules remain platform-neutral.
+
+## Governance hooks
+
+The core exposes governance seams but does not enforce one product's policy:
+
+- `SimulationContext.runtime_mode` states research or production posture.
+- `SimulationContext.provenance_labels` and `SocialEvent.provenance` preserve lineage.
+- `SimulationContext.governance_hooks` accepts caller-owned hook configuration.
+- `SocialEvent.metadata` and `SimulationResult.summary` carry audit references or hook results.
+- `RuntimeMode.PRODUCTION` is a signal to attach host-application controls before execution.
+
+Examples of hook families a production host may attach:
+
+- data minimization and PII validation;
+- scenario review/approval gates;
+- model card or experiment registry references;
+- human-in-the-loop review checkpoints;
+- safety, privacy, compliance, and audit logging callbacks;
+- rate limits and operational monitoring for non-synthetic integrations.
+
+These hook families are intentionally configuration points, not hard-coded core restrictions.
+
+## Deterministic runner baseline
+
+`DeterministicSimulationRunner` validates every action against the default `ActionRegistry`, emits one `SocialEvent` per action, and computes simple heuristic signals. Its baseline summary includes actor/content counts, platform mix, action counts, governance availability, and a synthetic-simulation disclaimer.
+
+This runner is intentionally simple so tests and architecture reviews can validate the core contracts before integrating stochastic LLM agents, external recommenders, or richer OASIS runtime adapters.
+
+## Extension rules
+
+When adding a new behavior, platform, vertical adapter, or signal:
+
+1. Add or reuse a `SocialBehaviorModule`; avoid hiding behavior inside a platform preset.
+2. Register normalized action verbs in `ACTION_DEFINITIONS`.
+3. Add a `SocialPlatformPreset` only for platform-surface composition.
+4. Keep vertical/domain assumptions in adapters, examples, or scenario files.
+5. Keep provenance labels and runtime mode explicit in contexts and results.
+6. Add tests that import the public `socialsense_core` API and verify registry coverage.
+7. Prefer typed dataclasses for new stable contracts; use `payload` or `metadata` for experiment-specific fields.
+
+## Acceptance coverage
+
+This Phase 2 baseline defines the required core abstractions:
+
+- `SocialAction`
+- `SocialEvent`
+- `SocialActor`
+- `SocialContent`
+- `SocialPlatformPreset`
+- `SocialBehaviorModule`
+- `SimulationContext`
+- `SimulationResult`
+- `RecommendationSignal`
+- `DiffusionSignal`
+- `OpinionSignal`
+- `TrustSignal`
+- `ProvenanceLabel`
+- `RuntimeMode`
+
+It also documents research-first behavior, behavior-driven platform composition, production governance hooks, and the explicit rule that reusable core modules should not contain project-specific hard-coded restrictions.

--- a/docs/socialsense/THAI_PLATFORM_PRIORITIES.md
+++ b/docs/socialsense/THAI_PLATFORM_PRIORITIES.md
@@ -1,0 +1,16 @@
+# Thai Platform Priorities
+
+## Tier 1
+
+- LINE — private groups, family/workplace groups, forwarded messages, high trust.
+- Facebook — groups, pages, marketplace behavior, live commerce later.
+- TikTok — short video, algorithmic discovery, creator affinity, social commerce.
+- YouTube — long-form explainers, Shorts, creator trust, subscriptions.
+
+## Tier 2
+
+Instagram, X / Twitter, Pantip.
+
+## Tier 3
+
+Threads, Discord, Lemon8, Bluesky, Messenger, Telegram, WhatsApp.

--- a/docs/socialsense/WORKSPACE_SETUP_LOG.md
+++ b/docs/socialsense/WORKSPACE_SETUP_LOG.md
@@ -1,0 +1,38 @@
+# Workspace Setup Log
+
+## Commands executed
+```bash
+mkdir -p /Users/chawit/Projects
+rm -rf /Users/chawit/Projects/oasis-socialsense-research
+git clone https://github.com/camel-ai/oasis /Users/chawit/Projects/oasis-socialsense-research
+cd /Users/chawit/Projects/oasis-socialsense-research
+git checkout -b feature/socialsense-core-foundation
+python3 --version
+git status --short --branch
+git rev-parse HEAD
+ls
+```
+
+## Environment capture
+```text
+Python 3.14.3
+## feature/socialsense-core-foundation
+?? docs/socialsense/
+9009941fb811f7925541a23dfcea66a9c5354f73
+CONTRIBUTING.md
+LICENSE
+README.md
+assets
+data
+deploy.py
+docs
+examples
+generator
+licenses
+log
+oasis
+poetry.lock
+pyproject.toml
+test
+visualization
+```

--- a/examples/socialsense_3c_adapter_demo.py
+++ b/examples/socialsense_3c_adapter_demo.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from socialsense_core.adapters.threec_marketing_adapter import simulate_campaign_response
+
+
+def main():
+    result = simulate_campaign_response(
+        campaign_message="Synthetic product launch campaign",
+        product_context="mock consumer product",
+        audience_profile={"name": "Synthetic value-seeking shoppers"},
+        platform_mix=["facebook", "tiktok", "youtube"],
+        runtime_mode="research",
+    )
+    print("input scenario:", result.scenario)
+    print("platform mix:", result.summary["platform_mix"])
+    print("actions simulated:", [e.action.action_type for e in result.event_log])
+    print("event log:", [e.event_id for e in result.event_log])
+    print("result summary:", dict(result.summary))
+    print("provenance labels:", [p.value for p in result.provenance_labels])
+    print("runtime mode:", result.runtime_mode.value)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/socialsense_civicsense_adapter_demo.py
+++ b/examples/socialsense_civicsense_adapter_demo.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from socialsense_core.adapters.civicsense_adapter import simulate_public_opinion
+
+
+def main():
+    result = simulate_public_opinion(
+        message="Synthetic policy explainer",
+        audience_profile={"name": "Synthetic Thai urban audience"},
+        platform_mix=["line", "facebook", "tiktok"],
+        scenario_context="demo only; no live platform data",
+        runtime_mode="research",
+    )
+    print("input scenario:", result.scenario)
+    print("platform mix:", result.summary["platform_mix"])
+    print("actions simulated:", [e.action.action_type for e in result.event_log])
+    print("event log:", [e.event_id for e in result.event_log])
+    print("result summary:", dict(result.summary))
+    print("provenance labels:", [p.value for p in result.provenance_labels])
+    print("runtime mode:", result.runtime_mode.value)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/socialsense_facebook_group_demo.py
+++ b/examples/socialsense_facebook_group_demo.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from socialsense_core import SocialAction, SocialActor, SocialContent, ProvenanceLabel, RuntimeMode
+from socialsense_core.simulation.context import SimulationContext
+from socialsense_core.simulation.runner import run_simulation
+
+
+def main():
+    scenario = 'Facebook group discussion with marketplace-adjacent sharing'
+    platform_mix = ['facebook']
+    actions = [SocialAction('post_topic', "actor-1", "content-1", platform='facebook'), SocialAction('comment', "actor-1", "content-1", platform='facebook'), SocialAction('react', "actor-1", "content-1", platform='facebook'), SocialAction('share', "actor-1", "content-1", platform='facebook'), SocialAction('view_product', "actor-1", "content-1", platform='facebook')]
+    context = SimulationContext.build(
+        scenario=scenario,
+        actors=[SocialActor("actor-1", "Synthetic Thai participant", traits={"country": "TH", "segment": "demo"})],
+        content=[SocialContent("content-1", 'Synthetic group post about a local product', author_id="source-1", topic="demo")],
+        platform_mix=platform_mix,
+        actions=actions,
+        runtime_mode=RuntimeMode.RESEARCH,
+        provenance_labels=(ProvenanceLabel.SYNTHETIC, ProvenanceLabel.MOCK),
+    )
+    result = run_simulation(context)
+    print("input scenario:", result.scenario)
+    print("platform mix:", result.summary["platform_mix"])
+    print("actions simulated:", [event.action.action_type for event in result.event_log])
+    print("event log:", [{"id": e.event_id, "action": e.action.action_type, "platform": e.action.platform} for e in result.event_log])
+    print("result summary:", dict(result.summary))
+    print("provenance labels:", [label.value for label in result.provenance_labels])
+    print("runtime mode:", result.runtime_mode.value)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/socialsense_line_group_demo.py
+++ b/examples/socialsense_line_group_demo.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from socialsense_core import SocialAction, SocialActor, SocialContent, ProvenanceLabel, RuntimeMode
+from socialsense_core.simulation.context import SimulationContext
+from socialsense_core.simulation.runner import run_simulation
+
+
+def main():
+    scenario = 'LINE family/workplace group forwards a public-health update'
+    platform_mix = ['line']
+    actions = [SocialAction('create_chat_group', "actor-1", "content-1", platform='line'), SocialAction('send_message', "actor-1", "content-1", platform='line'), SocialAction('forward_message', "actor-1", "content-1", platform='line'), SocialAction('listen_group', "actor-1", "content-1", platform='line'), SocialAction('correction_spread', "actor-1", "content-1", platform='line')]
+    context = SimulationContext.build(
+        scenario=scenario,
+        actors=[SocialActor("actor-1", "Synthetic Thai participant", traits={"country": "TH", "segment": "demo"})],
+        content=[SocialContent("content-1", 'Synthetic official update shared in a LINE group', author_id="source-1", topic="demo")],
+        platform_mix=platform_mix,
+        actions=actions,
+        runtime_mode=RuntimeMode.RESEARCH,
+        provenance_labels=(ProvenanceLabel.SYNTHETIC, ProvenanceLabel.MOCK),
+    )
+    result = run_simulation(context)
+    print("input scenario:", result.scenario)
+    print("platform mix:", result.summary["platform_mix"])
+    print("actions simulated:", [event.action.action_type for event in result.event_log])
+    print("event log:", [{"id": e.event_id, "action": e.action.action_type, "platform": e.action.platform} for e in result.event_log])
+    print("result summary:", dict(result.summary))
+    print("provenance labels:", [label.value for label in result.provenance_labels])
+    print("runtime mode:", result.runtime_mode.value)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/socialsense_thai_platform_mix_demo.py
+++ b/examples/socialsense_thai_platform_mix_demo.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from socialsense_core import SocialAction, SocialActor, SocialContent, ProvenanceLabel, RuntimeMode
+from socialsense_core.simulation.context import SimulationContext
+from socialsense_core.simulation.runner import run_simulation
+
+
+def main():
+    scenario = 'Thai platform mix: LINE, Facebook, TikTok, YouTube'
+    platform_mix = ['line', 'facebook', 'tiktok', 'youtube']
+    actions = [SocialAction('send_message', "actor-1", "content-1", platform='line'), SocialAction('post', "actor-1", "content-1", platform='facebook'), SocialAction('watch_video', "actor-1", "content-1", platform='tiktok'), SocialAction('share_video', "actor-1", "content-1", platform='tiktok'), SocialAction('watch_long_video', "actor-1", "content-1", platform='youtube'), SocialAction('update_sentiment', "actor-1", "content-1", platform='facebook')]
+    context = SimulationContext.build(
+        scenario=scenario,
+        actors=[SocialActor("actor-1", "Synthetic Thai participant", traits={"country": "TH", "segment": "demo"})],
+        content=[SocialContent("content-1", 'Synthetic cross-platform campaign message', author_id="source-1", topic="demo")],
+        platform_mix=platform_mix,
+        actions=actions,
+        runtime_mode=RuntimeMode.RESEARCH,
+        provenance_labels=(ProvenanceLabel.SYNTHETIC, ProvenanceLabel.MOCK),
+    )
+    result = run_simulation(context)
+    print("input scenario:", result.scenario)
+    print("platform mix:", result.summary["platform_mix"])
+    print("actions simulated:", [event.action.action_type for event in result.event_log])
+    print("event log:", [{"id": e.event_id, "action": e.action.action_type, "platform": e.action.platform} for e in result.event_log])
+    print("result summary:", dict(result.summary))
+    print("provenance labels:", [label.value for label in result.provenance_labels])
+    print("runtime mode:", result.runtime_mode.value)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/socialsense_tiktok_short_video_demo.py
+++ b/examples/socialsense_tiktok_short_video_demo.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from socialsense_core import SocialAction, SocialActor, SocialContent, ProvenanceLabel, RuntimeMode
+from socialsense_core.simulation.context import SimulationContext
+from socialsense_core.simulation.runner import run_simulation
+
+
+def main():
+    scenario = 'TikTok short-video discovery and creator affinity'
+    platform_mix = ['tiktok']
+    actions = [SocialAction('publish_video', "actor-1", "content-1", platform='tiktok'), SocialAction('watch_video', "actor-1", "content-1", platform='tiktok'), SocialAction('like_video', "actor-1", "content-1", platform='tiktok'), SocialAction('share_video', "actor-1", "content-1", platform='tiktok'), SocialAction('purchase_intent', "actor-1", "content-1", platform='tiktok')]
+    context = SimulationContext.build(
+        scenario=scenario,
+        actors=[SocialActor("actor-1", "Synthetic Thai participant", traits={"country": "TH", "segment": "demo"})],
+        content=[SocialContent("content-1", 'Synthetic short video message', author_id="source-1", topic="demo")],
+        platform_mix=platform_mix,
+        actions=actions,
+        runtime_mode=RuntimeMode.RESEARCH,
+        provenance_labels=(ProvenanceLabel.SYNTHETIC, ProvenanceLabel.MOCK),
+    )
+    result = run_simulation(context)
+    print("input scenario:", result.scenario)
+    print("platform mix:", result.summary["platform_mix"])
+    print("actions simulated:", [event.action.action_type for event in result.event_log])
+    print("event log:", [{"id": e.event_id, "action": e.action.action_type, "platform": e.action.platform} for e in result.event_log])
+    print("result summary:", dict(result.summary))
+    print("provenance labels:", [label.value for label in result.provenance_labels])
+    print("runtime mode:", result.runtime_mode.value)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/socialsense_youtube_video_demo.py
+++ b/examples/socialsense_youtube_video_demo.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from socialsense_core import SocialAction, SocialActor, SocialContent, ProvenanceLabel, RuntimeMode
+from socialsense_core.simulation.context import SimulationContext
+from socialsense_core.simulation.runner import run_simulation
+
+
+def main():
+    scenario = 'YouTube long-form explanation plus trust evaluation'
+    platform_mix = ['youtube']
+    actions = [SocialAction('publish_long_video', "actor-1", "content-1", platform='youtube'), SocialAction('watch_long_video', "actor-1", "content-1", platform='youtube'), SocialAction('subscribe_channel', "actor-1", "content-1", platform='youtube'), SocialAction('comment_video', "actor-1", "content-1", platform='youtube'), SocialAction('evaluate_source_trust', "actor-1", "content-1", platform='youtube')]
+    context = SimulationContext.build(
+        scenario=scenario,
+        actors=[SocialActor("actor-1", "Synthetic Thai participant", traits={"country": "TH", "segment": "demo"})],
+        content=[SocialContent("content-1", 'Synthetic explainer video', author_id="source-1", topic="demo")],
+        platform_mix=platform_mix,
+        actions=actions,
+        runtime_mode=RuntimeMode.RESEARCH,
+        provenance_labels=(ProvenanceLabel.SYNTHETIC, ProvenanceLabel.MOCK),
+    )
+    result = run_simulation(context)
+    print("input scenario:", result.scenario)
+    print("platform mix:", result.summary["platform_mix"])
+    print("actions simulated:", [event.action.action_type for event in result.event_log])
+    print("event log:", [{"id": e.event_id, "action": e.action.action_type, "platform": e.action.platform} for e in result.event_log])
+    print("result summary:", dict(result.summary))
+    print("provenance labels:", [label.value for label in result.provenance_labels])
+    print("runtime mode:", result.runtime_mode.value)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ keywords = [
 ]
 packages = [
     { include = "oasis" },
+    { include = "socialsense_core" },
 ]
 repository = "https://github.com/camel-ai/oasis.git"
 

--- a/socialsense_core/__init__.py
+++ b/socialsense_core/__init__.py
@@ -1,0 +1,13 @@
+from socialsense_core.actions.types import SocialAction
+from socialsense_core.behaviors.types import SocialBehaviorModule
+from socialsense_core.events.types import SocialEvent
+from socialsense_core.governance.labels import ProvenanceLabel
+from socialsense_core.governance.modes import RuntimeMode
+from socialsense_core.personas.types import SocialActor, SocialContent
+from socialsense_core.platforms.base import SocialPlatformPreset
+from socialsense_core.recommendation.base import DiffusionSignal, OpinionSignal, RecommendationSignal, TrustSignal
+from socialsense_core.simulation.context import SimulationContext
+from socialsense_core.simulation.result import SimulationResult
+from socialsense_core.simulation.runner import DeterministicSimulationRunner, run_simulation
+
+__all__ = ["SocialAction", "SocialEvent", "SocialActor", "SocialContent", "SocialPlatformPreset", "SocialBehaviorModule", "SimulationContext", "SimulationResult", "RecommendationSignal", "DiffusionSignal", "OpinionSignal", "TrustSignal", "ProvenanceLabel", "RuntimeMode", "DeterministicSimulationRunner", "run_simulation"]

--- a/socialsense_core/actions/__init__.py
+++ b/socialsense_core/actions/__init__.py
@@ -1,0 +1,4 @@
+from .registry import ActionRegistry, build_default_action_registry, get_default_action_registry
+from .types import ACTION_DEFINITIONS, SocialAction
+
+__all__ = ["ACTION_DEFINITIONS", "ActionRegistry", "SocialAction", "build_default_action_registry", "get_default_action_registry"]

--- a/socialsense_core/actions/registry.py
+++ b/socialsense_core/actions/registry.py
@@ -1,0 +1,31 @@
+from collections.abc import Iterable
+
+from .types import ACTION_DEFINITIONS
+
+
+class ActionRegistry:
+    def __init__(self) -> None:
+        self._actions: dict[str, set[str]] = {}
+
+    def register(self, behavior: str, actions: Iterable[str]) -> None:
+        self._actions.setdefault(behavior, set()).update(actions)
+
+    def has(self, action_type: str) -> bool:
+        return any(action_type in actions for actions in self._actions.values())
+
+    def actions_for(self, behavior: str) -> tuple[str, ...]:
+        return tuple(sorted(self._actions.get(behavior, ())))
+
+    def all_actions(self) -> tuple[str, ...]:
+        return tuple(sorted({action for actions in self._actions.values() for action in actions}))
+
+
+def build_default_action_registry() -> ActionRegistry:
+    registry = ActionRegistry()
+    for behavior, actions in ACTION_DEFINITIONS.items():
+        registry.register(behavior, actions)
+    return registry
+
+
+def get_default_action_registry() -> ActionRegistry:
+    return build_default_action_registry()

--- a/socialsense_core/actions/types.py
+++ b/socialsense_core/actions/types.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class SocialAction:
+    action_type: str
+    actor_id: str
+    content_id: str | None = None
+    target_id: str | None = None
+    platform: str | None = None
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+
+PUBLIC_FEED_ACTIONS = ("post", "comment", "react", "share", "follow", "refresh_feed")
+COMMUNITY_GROUP_ACTIONS = ("create_group", "join_group", "leave_group", "post_topic", "reply", "moderate")
+PRIVATE_MESSAGING_ACTIONS = ("send_message", "reply_message", "forward_message", "create_chat_group", "listen_group")
+SHORT_VIDEO_ACTIONS = ("publish_video", "watch_video", "skip_video", "like_video", "comment_video", "share_video", "follow_creator")
+LONG_FORM_VIDEO_ACTIONS = ("publish_long_video", "watch_long_video", "subscribe_channel", "comment_video", "share_video")
+INFLUENCER_NETWORK_ACTIONS = ("follow_influencer", "trust_influencer", "amplify_content", "creator_endorsement")
+RECOMMENDATION_ACTIONS = ("discover_content", "rank_feed", "search_topic", "trend_topic")
+INFORMATION_DIFFUSION_ACTIONS = ("expose_content", "propagate_content", "decay_attention")
+OPINION_FORMATION_ACTIONS = ("update_sentiment", "update_belief", "update_intent")
+TRUST_CREDIBILITY_ACTIONS = ("evaluate_source_trust", "update_trust_score")
+SOCIAL_COMMERCE_ACTIONS = ("view_product", "ask_for_review", "purchase_intent", "share_deal")
+CRISIS_SPREAD_ACTIONS = ("crisis_alert", "rumor_spread", "official_response", "correction_spread")
+
+ACTION_DEFINITIONS = {
+    "public_feed": PUBLIC_FEED_ACTIONS,
+    "community_group": COMMUNITY_GROUP_ACTIONS,
+    "private_messaging": PRIVATE_MESSAGING_ACTIONS,
+    "short_video": SHORT_VIDEO_ACTIONS,
+    "long_form_video": LONG_FORM_VIDEO_ACTIONS,
+    "influencer_network": INFLUENCER_NETWORK_ACTIONS,
+    "recommendation_discovery": RECOMMENDATION_ACTIONS,
+    "information_diffusion": INFORMATION_DIFFUSION_ACTIONS,
+    "opinion_formation": OPINION_FORMATION_ACTIONS,
+    "trust_credibility": TRUST_CREDIBILITY_ACTIONS,
+    "social_commerce": SOCIAL_COMMERCE_ACTIONS,
+    "crisis_spread": CRISIS_SPREAD_ACTIONS,
+}

--- a/socialsense_core/adapters/civicsense_adapter.py
+++ b/socialsense_core/adapters/civicsense_adapter.py
@@ -1,0 +1,39 @@
+from socialsense_core.actions.types import SocialAction
+from socialsense_core.governance.labels import ProvenanceLabel
+from socialsense_core.governance.modes import RuntimeMode
+from socialsense_core.personas.types import SocialActor, SocialContent
+from socialsense_core.simulation.context import SimulationContext
+from socialsense_core.simulation.runner import run_simulation
+
+
+def _actors(audience_profile):
+    if isinstance(audience_profile, dict):
+        name = audience_profile.get("name", "Synthetic audience")
+        traits = audience_profile
+    else:
+        name = str(audience_profile or "Synthetic audience")
+        traits = {"profile": name}
+    return [SocialActor(actor_id="audience-1", display_name=name, traits=traits)]
+
+
+def _run(scenario, message, audience_profile, platform_mix, runtime_mode, actions):
+    content = [SocialContent(content_id="message-1", text=message, author_id="source", topic="scenario")]
+    context = SimulationContext.build(
+        scenario=scenario, actors=_actors(audience_profile), content=content, platform_mix=list(platform_mix or ["line", "facebook"]), actions=actions, runtime_mode=runtime_mode, provenance_labels=(ProvenanceLabel.SYNTHETIC, ProvenanceLabel.HUMAN_AUTHORED_SCENARIO), governance_hooks={"downstream_policy_boundary": "application-owned"},
+    )
+    return run_simulation(context)
+
+
+def simulate_public_opinion(message, audience_profile, platform_mix, scenario_context, runtime_mode="research"):
+    actions = [SocialAction("post", "audience-1", "message-1", platform=(platform_mix or ["facebook"])[0]), SocialAction("react", "audience-1", "message-1"), SocialAction("share", "audience-1", "message-1"), SocialAction("update_sentiment", "audience-1", "message-1")]
+    return _run(f"public opinion: {scenario_context}", message, audience_profile, platform_mix, runtime_mode, actions)
+
+
+def simulate_crisis_response(crisis_message, audience_profile, platform_mix, scenario_context, runtime_mode="research"):
+    actions = [SocialAction("crisis_alert", "audience-1", "message-1"), SocialAction("rumor_spread", "audience-1", "message-1"), SocialAction("official_response", "audience-1", "message-1"), SocialAction("correction_spread", "audience-1", "message-1")]
+    return _run(f"crisis response: {scenario_context}", crisis_message, audience_profile, platform_mix, runtime_mode, actions)
+
+
+def simulate_policy_message_diffusion(policy_message, audience_profile, platform_mix, scenario_context, runtime_mode="research"):
+    actions = [SocialAction("post", "audience-1", "message-1"), SocialAction("expose_content", "audience-1", "message-1"), SocialAction("propagate_content", "audience-1", "message-1"), SocialAction("update_belief", "audience-1", "message-1")]
+    return _run(f"policy diffusion: {scenario_context}", policy_message, audience_profile, platform_mix, runtime_mode, actions)

--- a/socialsense_core/adapters/threec_marketing_adapter.py
+++ b/socialsense_core/adapters/threec_marketing_adapter.py
@@ -1,0 +1,39 @@
+from socialsense_core.actions.types import SocialAction
+from socialsense_core.governance.labels import ProvenanceLabel
+from socialsense_core.governance.modes import RuntimeMode
+from socialsense_core.personas.types import SocialActor, SocialContent
+from socialsense_core.simulation.context import SimulationContext
+from socialsense_core.simulation.runner import run_simulation
+
+
+def _actors(audience_profile):
+    if isinstance(audience_profile, dict):
+        name = audience_profile.get("name", "Synthetic audience")
+        traits = audience_profile
+    else:
+        name = str(audience_profile or "Synthetic audience")
+        traits = {"profile": name}
+    return [SocialActor(actor_id="audience-1", display_name=name, traits=traits)]
+
+
+def _run(scenario, message, audience_profile, platform_mix, runtime_mode, actions):
+    content = [SocialContent(content_id="message-1", text=message, author_id="source", topic="scenario")]
+    context = SimulationContext.build(
+        scenario=scenario, actors=_actors(audience_profile), content=content, platform_mix=list(platform_mix or ["line", "facebook"]), actions=actions, runtime_mode=runtime_mode, provenance_labels=(ProvenanceLabel.SYNTHETIC, ProvenanceLabel.HUMAN_AUTHORED_SCENARIO), governance_hooks={"downstream_policy_boundary": "application-owned"},
+    )
+    return run_simulation(context)
+
+
+def simulate_campaign_response(campaign_message, product_context, audience_profile, platform_mix, runtime_mode="research"):
+    actions = [SocialAction("post", "audience-1", "message-1"), SocialAction("discover_content", "audience-1", "message-1"), SocialAction("react", "audience-1", "message-1"), SocialAction("purchase_intent", "audience-1", "message-1", payload={"product_context": product_context})]
+    return _run(f"campaign response: {product_context}", campaign_message, audience_profile, platform_mix, runtime_mode, actions)
+
+
+def simulate_brand_sentiment(brand_message, audience_profile, platform_mix, runtime_mode="research"):
+    actions = [SocialAction("post", "audience-1", "message-1"), SocialAction("comment", "audience-1", "message-1"), SocialAction("update_sentiment", "audience-1", "message-1"), SocialAction("evaluate_source_trust", "audience-1", "message-1")]
+    return _run("brand sentiment", brand_message, audience_profile, platform_mix, runtime_mode, actions)
+
+
+def simulate_social_commerce_response(offer_message, product_context, audience_profile, platform_mix, runtime_mode="research"):
+    actions = [SocialAction("view_product", "audience-1", "message-1", payload={"product_context": product_context}), SocialAction("ask_for_review", "audience-1", "message-1"), SocialAction("purchase_intent", "audience-1", "message-1"), SocialAction("share_deal", "audience-1", "message-1")]
+    return _run(f"social commerce: {product_context}", offer_message, audience_profile, platform_mix, runtime_mode, actions)

--- a/socialsense_core/behaviors/__init__.py
+++ b/socialsense_core/behaviors/__init__.py
@@ -1,0 +1,4 @@
+from .types import SocialBehaviorModule
+from .registry import BehaviorModuleRegistry, get_default_behavior_registry
+
+__all__ = ["BehaviorModuleRegistry", "SocialBehaviorModule", "get_default_behavior_registry"]

--- a/socialsense_core/behaviors/community_group.py
+++ b/socialsense_core/behaviors/community_group.py
@@ -1,0 +1,10 @@
+from socialsense_core.actions.types import ACTION_DEFINITIONS
+from .types import SocialBehaviorModule
+
+MODULE = SocialBehaviorModule(
+    key="community_group",
+    name="Community Group",
+    actions=tuple(ACTION_DEFINITIONS["community_group"]),
+    description="Reusable behavior module for community group simulations.",
+    signals=(),
+)

--- a/socialsense_core/behaviors/crisis_spread.py
+++ b/socialsense_core/behaviors/crisis_spread.py
@@ -1,0 +1,10 @@
+from socialsense_core.actions.types import ACTION_DEFINITIONS
+from .types import SocialBehaviorModule
+
+MODULE = SocialBehaviorModule(
+    key="crisis_spread",
+    name="Crisis Spread",
+    actions=tuple(ACTION_DEFINITIONS["crisis_spread"]),
+    description="Reusable behavior module for crisis spread simulations.",
+    signals=(),
+)

--- a/socialsense_core/behaviors/influencer_network.py
+++ b/socialsense_core/behaviors/influencer_network.py
@@ -1,0 +1,10 @@
+from socialsense_core.actions.types import ACTION_DEFINITIONS
+from .types import SocialBehaviorModule
+
+MODULE = SocialBehaviorModule(
+    key="influencer_network",
+    name="Influencer Network",
+    actions=tuple(ACTION_DEFINITIONS["influencer_network"]),
+    description="Reusable behavior module for influencer network simulations.",
+    signals=(),
+)

--- a/socialsense_core/behaviors/information_diffusion.py
+++ b/socialsense_core/behaviors/information_diffusion.py
@@ -1,0 +1,10 @@
+from socialsense_core.actions.types import ACTION_DEFINITIONS
+from .types import SocialBehaviorModule
+
+MODULE = SocialBehaviorModule(
+    key="information_diffusion",
+    name="Information Diffusion",
+    actions=tuple(ACTION_DEFINITIONS["information_diffusion"]),
+    description="Reusable behavior module for information diffusion simulations.",
+    signals=("DiffusionSignal",),
+)

--- a/socialsense_core/behaviors/long_form_video.py
+++ b/socialsense_core/behaviors/long_form_video.py
@@ -1,0 +1,10 @@
+from socialsense_core.actions.types import ACTION_DEFINITIONS
+from .types import SocialBehaviorModule
+
+MODULE = SocialBehaviorModule(
+    key="long_form_video",
+    name="Long-form Video",
+    actions=tuple(ACTION_DEFINITIONS["long_form_video"]),
+    description="Reusable behavior module for long-form video simulations.",
+    signals=(),
+)

--- a/socialsense_core/behaviors/opinion_formation.py
+++ b/socialsense_core/behaviors/opinion_formation.py
@@ -1,0 +1,10 @@
+from socialsense_core.actions.types import ACTION_DEFINITIONS
+from .types import SocialBehaviorModule
+
+MODULE = SocialBehaviorModule(
+    key="opinion_formation",
+    name="Opinion Formation",
+    actions=tuple(ACTION_DEFINITIONS["opinion_formation"]),
+    description="Reusable behavior module for opinion formation simulations.",
+    signals=("OpinionSignal",),
+)

--- a/socialsense_core/behaviors/private_messaging.py
+++ b/socialsense_core/behaviors/private_messaging.py
@@ -1,0 +1,10 @@
+from socialsense_core.actions.types import ACTION_DEFINITIONS
+from .types import SocialBehaviorModule
+
+MODULE = SocialBehaviorModule(
+    key="private_messaging",
+    name="Private Messaging",
+    actions=tuple(ACTION_DEFINITIONS["private_messaging"]),
+    description="Reusable behavior module for private messaging simulations.",
+    signals=(),
+)

--- a/socialsense_core/behaviors/public_feed.py
+++ b/socialsense_core/behaviors/public_feed.py
@@ -1,0 +1,10 @@
+from socialsense_core.actions.types import ACTION_DEFINITIONS
+from .types import SocialBehaviorModule
+
+MODULE = SocialBehaviorModule(
+    key="public_feed",
+    name="Public Feed",
+    actions=tuple(ACTION_DEFINITIONS["public_feed"]),
+    description="Reusable behavior module for public feed simulations.",
+    signals=(),
+)

--- a/socialsense_core/behaviors/recommendation.py
+++ b/socialsense_core/behaviors/recommendation.py
@@ -1,0 +1,10 @@
+from socialsense_core.actions.types import ACTION_DEFINITIONS
+from .types import SocialBehaviorModule
+
+MODULE = SocialBehaviorModule(
+    key="recommendation",
+    name="Recommendation / Discovery",
+    actions=tuple(ACTION_DEFINITIONS["recommendation_discovery"]),
+    description="Reusable behavior module for recommendation / discovery simulations.",
+    signals=("RecommendationSignal",),
+)

--- a/socialsense_core/behaviors/registry.py
+++ b/socialsense_core/behaviors/registry.py
@@ -1,0 +1,29 @@
+from .types import SocialBehaviorModule
+from . import public_feed, community_group, private_messaging, short_video, long_form_video, influencer_network, recommendation, information_diffusion, opinion_formation, trust_credibility, social_commerce, crisis_spread
+
+DEFAULT_MODULES = (
+    public_feed.MODULE, community_group.MODULE, private_messaging.MODULE, short_video.MODULE, long_form_video.MODULE,
+    influencer_network.MODULE, recommendation.MODULE, information_diffusion.MODULE, opinion_formation.MODULE,
+    trust_credibility.MODULE, social_commerce.MODULE, crisis_spread.MODULE,
+)
+
+
+class BehaviorModuleRegistry:
+    def __init__(self, modules: tuple[SocialBehaviorModule, ...] = DEFAULT_MODULES) -> None:
+        self._modules = {module.key: module for module in modules}
+
+    def register(self, module: SocialBehaviorModule) -> None:
+        self._modules[module.key] = module
+
+    def get(self, key: str) -> SocialBehaviorModule:
+        return self._modules[key]
+
+    def keys(self) -> tuple[str, ...]:
+        return tuple(sorted(self._modules))
+
+    def all(self) -> tuple[SocialBehaviorModule, ...]:
+        return tuple(self._modules[key] for key in self.keys())
+
+
+def get_default_behavior_registry() -> BehaviorModuleRegistry:
+    return BehaviorModuleRegistry()

--- a/socialsense_core/behaviors/short_video.py
+++ b/socialsense_core/behaviors/short_video.py
@@ -1,0 +1,10 @@
+from socialsense_core.actions.types import ACTION_DEFINITIONS
+from .types import SocialBehaviorModule
+
+MODULE = SocialBehaviorModule(
+    key="short_video",
+    name="Short Video",
+    actions=tuple(ACTION_DEFINITIONS["short_video"]),
+    description="Reusable behavior module for short video simulations.",
+    signals=(),
+)

--- a/socialsense_core/behaviors/social_commerce.py
+++ b/socialsense_core/behaviors/social_commerce.py
@@ -1,0 +1,10 @@
+from socialsense_core.actions.types import ACTION_DEFINITIONS
+from .types import SocialBehaviorModule
+
+MODULE = SocialBehaviorModule(
+    key="social_commerce",
+    name="Social Commerce",
+    actions=tuple(ACTION_DEFINITIONS["social_commerce"]),
+    description="Reusable behavior module for social commerce simulations.",
+    signals=(),
+)

--- a/socialsense_core/behaviors/trust_credibility.py
+++ b/socialsense_core/behaviors/trust_credibility.py
@@ -1,0 +1,10 @@
+from socialsense_core.actions.types import ACTION_DEFINITIONS
+from .types import SocialBehaviorModule
+
+MODULE = SocialBehaviorModule(
+    key="trust_credibility",
+    name="Trust / Credibility",
+    actions=tuple(ACTION_DEFINITIONS["trust_credibility"]),
+    description="Reusable behavior module for trust / credibility simulations.",
+    signals=("TrustSignal",),
+)

--- a/socialsense_core/behaviors/types.py
+++ b/socialsense_core/behaviors/types.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass, field
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class SocialBehaviorModule:
+    key: str
+    name: str
+    actions: tuple[str, ...]
+    description: str
+    signals: tuple[str, ...] = ()
+    metadata: Mapping[str, str] = field(default_factory=dict)

--- a/socialsense_core/events/__init__.py
+++ b/socialsense_core/events/__init__.py
@@ -1,0 +1,4 @@
+from .event_log import EventLog
+from .types import SocialEvent
+
+__all__ = ["EventLog", "SocialEvent"]

--- a/socialsense_core/events/event_log.py
+++ b/socialsense_core/events/event_log.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass, field
+
+from .types import SocialEvent
+
+
+@dataclass
+class EventLog:
+    events: list[SocialEvent] = field(default_factory=list)
+
+    def append(self, event: SocialEvent) -> None:
+        self.events.append(event)
+
+    def __iter__(self):
+        return iter(self.events)
+
+    def __len__(self) -> int:
+        return len(self.events)
+
+    def by_action(self, action_type: str) -> tuple[SocialEvent, ...]:
+        return tuple(event for event in self.events if event.action.action_type == action_type)
+
+    def to_summary(self) -> dict[str, int]:
+        summary: dict[str, int] = {}
+        for event in self.events:
+            summary[event.action.action_type] = summary.get(event.action.action_type, 0) + 1
+        return summary

--- a/socialsense_core/events/types.py
+++ b/socialsense_core/events/types.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from socialsense_core.actions.types import SocialAction
+from socialsense_core.governance.labels import ProvenanceLabel
+
+
+@dataclass(frozen=True)
+class SocialEvent:
+    event_id: str
+    action: SocialAction
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    provenance: tuple[ProvenanceLabel, ...] = (ProvenanceLabel.SYNTHETIC,)
+    metadata: Mapping[str, Any] = field(default_factory=dict)

--- a/socialsense_core/governance/labels.py
+++ b/socialsense_core/governance/labels.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Mapping
+
+
+class ProvenanceLabel(str, Enum):
+    SYNTHETIC = "synthetic"
+    MOCK = "mock"
+    ANONYMIZED = "anonymized"
+    OASIS_DERIVED_MAPPING = "oasis_derived_mapping"
+    HUMAN_AUTHORED_SCENARIO = "human_authored_scenario"
+
+
+@dataclass(frozen=True)
+class ProvenanceRecord:
+    label: ProvenanceLabel
+    note: str = ""
+    metadata: Mapping[str, str] = field(default_factory=dict)

--- a/socialsense_core/governance/modes.py
+++ b/socialsense_core/governance/modes.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class RuntimeMode(str, Enum):
+    RESEARCH = "research"
+    PRODUCTION = "production"
+
+
+def normalize_runtime_mode(mode: str | RuntimeMode) -> RuntimeMode:
+    if isinstance(mode, RuntimeMode):
+        return mode
+    return RuntimeMode(str(mode).lower())

--- a/socialsense_core/personas/types.py
+++ b/socialsense_core/personas/types.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class SocialActor:
+    actor_id: str
+    display_name: str
+    traits: Mapping[str, Any] = field(default_factory=dict)
+    trust_score: float = 0.5
+    sentiment: float = 0.0
+    belief: float = 0.0
+    intent: float = 0.0
+
+
+@dataclass(frozen=True)
+class SocialContent:
+    content_id: str
+    text: str
+    author_id: str | None = None
+    topic: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)

--- a/socialsense_core/platforms/__init__.py
+++ b/socialsense_core/platforms/__init__.py
@@ -1,0 +1,4 @@
+from .base import SocialPlatformPreset
+from .registry import PlatformPresetRegistry, get_default_platform_registry
+
+__all__ = ["PlatformPresetRegistry", "SocialPlatformPreset", "get_default_platform_registry"]

--- a/socialsense_core/platforms/base.py
+++ b/socialsense_core/platforms/base.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass, field
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class SocialPlatformPreset:
+    key: str
+    display_name: str
+    behavior_modules: tuple[str, ...]
+    actions: tuple[str, ...]
+    recommendation_signals: tuple[str, ...] = ()
+    context_notes: tuple[str, ...] = ()
+    oasis_mapping: Mapping[str, str] = field(default_factory=dict)

--- a/socialsense_core/platforms/facebook.py
+++ b/socialsense_core/platforms/facebook.py
@@ -1,0 +1,11 @@
+from .base import SocialPlatformPreset
+
+PRESET = SocialPlatformPreset(
+    key='facebook',
+    display_name='Facebook',
+    behavior_modules=('public_feed', 'community_group', 'influencer_network', 'social_commerce', 'crisis_spread'),
+    actions=('post', 'comment', 'react', 'share', 'join_group', 'follow', 'post_topic', 'view_product', 'share_deal'),
+    recommendation_signals=('group_activity', 'page_follow', 'marketplace_intent'),
+    context_notes=('Groups, pages, marketplace behavior, and live commerce can be modeled by adapters without hard-coding a locale.',),
+    oasis_mapping={},
+)

--- a/socialsense_core/platforms/line.py
+++ b/socialsense_core/platforms/line.py
@@ -1,0 +1,11 @@
+from .base import SocialPlatformPreset
+
+PRESET = SocialPlatformPreset(
+    key='line',
+    display_name='LINE',
+    behavior_modules=('private_messaging', 'community_group', 'trust_credibility', 'information_diffusion', 'crisis_spread'),
+    actions=('create_chat_group', 'join_group', 'leave_group', 'send_message', 'reply_message', 'forward_message', 'listen_group', 'rumor_spread', 'correction_spread'),
+    recommendation_signals=('forward_rate', 'group_trust', 'official_account_future'),
+    context_notes=('Private and group messaging, high-trust groups, and forwarded messages can be modeled by adapters without hard-coding a locale.',),
+    oasis_mapping={},
+)

--- a/socialsense_core/platforms/reddit.py
+++ b/socialsense_core/platforms/reddit.py
@@ -1,0 +1,11 @@
+from .base import SocialPlatformPreset
+
+PRESET = SocialPlatformPreset(
+    key='reddit',
+    display_name='Reddit',
+    behavior_modules=('community_group', 'public_feed', 'trust_credibility', 'information_diffusion'),
+    actions=('post_topic', 'reply', 'react', 'moderate', 'join_group'),
+    recommendation_signals=('hot_score', 'upvote_downvote_equivalent', 'community_trust'),
+    context_notes=('OASIS Reddit uses show_score/hot-score recsys and default reddit actions.', 'LIKE/DISLIKE map to react with polarity.'),
+    oasis_mapping={'CREATE_POST': 'post_topic', 'CREATE_COMMENT': 'reply', 'LIKE_POST': 'react', 'DISLIKE_POST': 'react', 'JOIN_GROUP': 'join_group', 'REPORT_POST': 'moderate'},
+)

--- a/socialsense_core/platforms/registry.py
+++ b/socialsense_core/platforms/registry.py
@@ -1,0 +1,25 @@
+from .base import SocialPlatformPreset
+from . import x_twitter, reddit, line, facebook, tiktok, youtube
+
+DEFAULT_PRESETS = (x_twitter.PRESET, reddit.PRESET, line.PRESET, facebook.PRESET, tiktok.PRESET, youtube.PRESET)
+
+
+class PlatformPresetRegistry:
+    def __init__(self, presets: tuple[SocialPlatformPreset, ...] = DEFAULT_PRESETS) -> None:
+        self._presets = {preset.key: preset for preset in presets}
+
+    def register(self, preset: SocialPlatformPreset) -> None:
+        self._presets[preset.key] = preset
+
+    def get(self, key: str) -> SocialPlatformPreset:
+        return self._presets[key]
+
+    def keys(self) -> tuple[str, ...]:
+        return tuple(sorted(self._presets))
+
+    def all(self) -> tuple[SocialPlatformPreset, ...]:
+        return tuple(self._presets[key] for key in self.keys())
+
+
+def get_default_platform_registry() -> PlatformPresetRegistry:
+    return PlatformPresetRegistry()

--- a/socialsense_core/platforms/tiktok.py
+++ b/socialsense_core/platforms/tiktok.py
@@ -1,0 +1,11 @@
+from .base import SocialPlatformPreset
+
+PRESET = SocialPlatformPreset(
+    key='tiktok',
+    display_name='TikTok',
+    behavior_modules=('short_video', 'influencer_network', 'recommendation', 'social_commerce', 'opinion_formation'),
+    actions=('publish_video', 'watch_video', 'skip_video', 'like_video', 'comment_video', 'share_video', 'follow_creator', 'discover_content', 'purchase_intent'),
+    recommendation_signals=('watch_time', 'completion_rate', 'engagement', 'creator_affinity', 'topic_affinity'),
+    context_notes=('Short-video algorithmic discovery and creator affinity.',),
+    oasis_mapping={},
+)

--- a/socialsense_core/platforms/x_twitter.py
+++ b/socialsense_core/platforms/x_twitter.py
@@ -1,0 +1,11 @@
+from .base import SocialPlatformPreset
+
+PRESET = SocialPlatformPreset(
+    key='x_twitter',
+    display_name='X / Twitter',
+    behavior_modules=('public_feed', 'recommendation', 'information_diffusion', 'opinion_formation'),
+    actions=('post', 'comment', 'react', 'share', 'follow', 'search_topic', 'trend_topic', 'refresh_feed'),
+    recommendation_signals=('engagement', 'recency', 'topic_affinity'),
+    context_notes=('OASIS ActionType.CREATE_POST -> post', 'LIKE_POST -> react', 'REPOST/QUOTE_POST -> share', 'FOLLOW -> follow', 'SEARCH_POSTS/TREND/REFRESH -> search_topic/trend_topic/refresh_feed'),
+    oasis_mapping={'CREATE_POST': 'post', 'CREATE_COMMENT': 'comment', 'LIKE_POST': 'react', 'REPOST': 'share', 'QUOTE_POST': 'share', 'FOLLOW': 'follow', 'SEARCH_POSTS': 'search_topic', 'TREND': 'trend_topic', 'REFRESH': 'refresh_feed'},
+)

--- a/socialsense_core/platforms/youtube.py
+++ b/socialsense_core/platforms/youtube.py
@@ -1,0 +1,11 @@
+from .base import SocialPlatformPreset
+
+PRESET = SocialPlatformPreset(
+    key='youtube',
+    display_name='YouTube',
+    behavior_modules=('long_form_video', 'short_video', 'influencer_network', 'recommendation', 'trust_credibility'),
+    actions=('publish_long_video', 'watch_long_video', 'publish_video', 'watch_video', 'subscribe_channel', 'comment_video', 'share_video', 'evaluate_source_trust'),
+    recommendation_signals=('watch_time', 'subscription_affinity', 'source_credibility'),
+    context_notes=('Long-form plus Shorts with channel trust and subscriptions.',),
+    oasis_mapping={},
+)

--- a/socialsense_core/recommendation/__init__.py
+++ b/socialsense_core/recommendation/__init__.py
@@ -1,0 +1,4 @@
+from .base import DiffusionSignal, OpinionSignal, RecommendationSignal, TrustSignal
+from .heuristics import diffusion_heuristic, opinion_update_heuristic, recommendation_heuristic, trust_heuristic
+
+__all__ = ["DiffusionSignal", "OpinionSignal", "RecommendationSignal", "TrustSignal", "diffusion_heuristic", "opinion_update_heuristic", "recommendation_heuristic", "trust_heuristic"]

--- a/socialsense_core/recommendation/base.py
+++ b/socialsense_core/recommendation/base.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RecommendationSignal:
+    content_id: str
+    score: float
+    reason: str
+
+
+@dataclass(frozen=True)
+class DiffusionSignal:
+    content_id: str
+    reach: float
+    velocity: float
+    reason: str
+
+
+@dataclass(frozen=True)
+class OpinionSignal:
+    actor_id: str
+    sentiment_delta: float
+    belief_delta: float
+    intent_delta: float
+    reason: str
+
+
+@dataclass(frozen=True)
+class TrustSignal:
+    actor_id: str
+    trust_delta: float
+    reason: str

--- a/socialsense_core/recommendation/heuristics.py
+++ b/socialsense_core/recommendation/heuristics.py
@@ -1,0 +1,47 @@
+from collections import Counter
+
+from socialsense_core.actions.types import SocialAction
+from .base import DiffusionSignal, OpinionSignal, RecommendationSignal, TrustSignal
+
+ENGAGEMENT_WEIGHTS = {
+    "post": 1.0, "comment": 0.5, "reply": 0.45, "react": 0.3, "share": 0.8, "follow": 0.4,
+    "watch_video": 0.5, "like_video": 0.4, "share_video": 0.8, "subscribe_channel": 0.6,
+    "propagate_content": 1.0, "rumor_spread": 0.9, "official_response": 0.7, "correction_spread": 0.7,
+    "purchase_intent": 0.6, "view_product": 0.2,
+}
+
+
+def recommendation_heuristic(actions: list[SocialAction]) -> list[RecommendationSignal]:
+    scores: Counter[str] = Counter()
+    for action in actions:
+        content_id = action.content_id or action.target_id or action.payload.get("content_id") or "scenario"
+        scores[str(content_id)] += ENGAGEMENT_WEIGHTS.get(action.action_type, 0.1)
+    return [RecommendationSignal(content_id=k, score=round(v, 4), reason="deterministic engagement-weight heuristic") for k, v in sorted(scores.items())]
+
+
+def diffusion_heuristic(actions: list[SocialAction]) -> list[DiffusionSignal]:
+    out = []
+    for signal in recommendation_heuristic(actions):
+        share_count = sum(1 for a in actions if (a.content_id or a.target_id or a.payload.get("content_id") or "scenario") == signal.content_id and a.action_type in {"share", "share_video", "forward_message", "propagate_content", "rumor_spread"})
+        out.append(DiffusionSignal(signal.content_id, reach=round(signal.score * (1 + share_count), 4), velocity=round(0.1 + share_count * 0.2, 4), reason="reach = engagement score multiplied by propagation actions"))
+    return out
+
+
+def opinion_update_heuristic(actions: list[SocialAction]) -> list[OpinionSignal]:
+    by_actor: Counter[str] = Counter()
+    for a in actions:
+        if a.action_type in {"react", "like_video", "comment", "comment_video", "reply", "update_sentiment", "update_belief", "update_intent", "purchase_intent"}:
+            by_actor[a.actor_id] += 1
+        if a.action_type in {"skip_video", "decay_attention"}:
+            by_actor[a.actor_id] -= 1
+    return [OpinionSignal(actor_id=k, sentiment_delta=round(v * 0.05, 4), belief_delta=round(v * 0.03, 4), intent_delta=round(v * 0.02, 4), reason="small deterministic delta from engagement polarity") for k, v in sorted(by_actor.items())]
+
+
+def trust_heuristic(actions: list[SocialAction]) -> list[TrustSignal]:
+    by_actor: Counter[str] = Counter()
+    for a in actions:
+        if a.action_type in {"evaluate_source_trust", "trust_influencer", "official_response", "correction_spread"}:
+            by_actor[a.actor_id] += 1
+        if a.action_type in {"rumor_spread"}:
+            by_actor[a.actor_id] -= 1
+    return [TrustSignal(actor_id=k, trust_delta=round(v * 0.04, 4), reason="trust increases for verification/official response, decreases for rumor spread") for k, v in sorted(by_actor.items())]

--- a/socialsense_core/simulation/__init__.py
+++ b/socialsense_core/simulation/__init__.py
@@ -1,0 +1,5 @@
+from .context import SimulationContext
+from .result import SimulationResult
+from .runner import DeterministicSimulationRunner, run_simulation
+
+__all__ = ["DeterministicSimulationRunner", "SimulationContext", "SimulationResult", "run_simulation"]

--- a/socialsense_core/simulation/context.py
+++ b/socialsense_core/simulation/context.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from socialsense_core.actions.types import SocialAction
+from socialsense_core.governance.labels import ProvenanceLabel
+from socialsense_core.governance.modes import RuntimeMode, normalize_runtime_mode
+from socialsense_core.personas.types import SocialActor, SocialContent
+
+
+@dataclass(frozen=True)
+class SimulationContext:
+    scenario: str
+    actors: tuple[SocialActor, ...]
+    content: tuple[SocialContent, ...]
+    platform_mix: tuple[str, ...]
+    actions: tuple[SocialAction, ...]
+    runtime_mode: RuntimeMode = RuntimeMode.RESEARCH
+    provenance_labels: tuple[ProvenanceLabel, ...] = (ProvenanceLabel.SYNTHETIC,)
+    governance_hooks: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def build(cls, scenario: str, actors: list[SocialActor], content: list[SocialContent], platform_mix: list[str], actions: list[SocialAction], runtime_mode: str | RuntimeMode = RuntimeMode.RESEARCH, provenance_labels: tuple[ProvenanceLabel, ...] = (ProvenanceLabel.SYNTHETIC,), governance_hooks: Mapping[str, Any] | None = None) -> "SimulationContext":
+        return cls(scenario=scenario, actors=tuple(actors), content=tuple(content), platform_mix=tuple(platform_mix), actions=tuple(actions), runtime_mode=normalize_runtime_mode(runtime_mode), provenance_labels=provenance_labels, governance_hooks=governance_hooks or {})

--- a/socialsense_core/simulation/result.py
+++ b/socialsense_core/simulation/result.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from socialsense_core.events.event_log import EventLog
+from socialsense_core.governance.labels import ProvenanceLabel
+from socialsense_core.governance.modes import RuntimeMode
+from socialsense_core.recommendation.base import DiffusionSignal, OpinionSignal, RecommendationSignal, TrustSignal
+
+
+@dataclass(frozen=True)
+class SimulationResult:
+    scenario: str
+    runtime_mode: RuntimeMode
+    event_log: EventLog
+    recommendation_signals: tuple[RecommendationSignal, ...]
+    diffusion_signals: tuple[DiffusionSignal, ...]
+    opinion_signals: tuple[OpinionSignal, ...]
+    trust_signals: tuple[TrustSignal, ...]
+    provenance_labels: tuple[ProvenanceLabel, ...]
+    summary: Mapping[str, Any] = field(default_factory=dict)

--- a/socialsense_core/simulation/runner.py
+++ b/socialsense_core/simulation/runner.py
@@ -1,0 +1,45 @@
+from datetime import datetime, timezone
+
+from socialsense_core.actions.registry import build_default_action_registry
+from socialsense_core.events.event_log import EventLog
+from socialsense_core.events.types import SocialEvent
+from socialsense_core.governance.modes import RuntimeMode
+from socialsense_core.recommendation.heuristics import diffusion_heuristic, opinion_update_heuristic, recommendation_heuristic, trust_heuristic
+from .context import SimulationContext
+from .result import SimulationResult
+
+
+class DeterministicSimulationRunner:
+    def __init__(self) -> None:
+        self.action_registry = build_default_action_registry()
+
+    def run(self, context: SimulationContext) -> SimulationResult:
+        unknown = [a.action_type for a in context.actions if not self.action_registry.has(a.action_type)]
+        if unknown:
+            raise ValueError(f"Unsupported action types: {unknown}")
+        event_log = EventLog()
+        for idx, action in enumerate(context.actions):
+            event_log.append(SocialEvent(
+                event_id=f"evt-{idx + 1:04d}",
+                action=action,
+                timestamp=datetime.fromtimestamp(idx, timezone.utc),
+                provenance=context.provenance_labels,
+                metadata={"runtime_mode": context.runtime_mode.value, "platform": action.platform or "mixed"},
+            ))
+        recommendations = tuple(recommendation_heuristic(list(context.actions)))
+        diffusion = tuple(diffusion_heuristic(list(context.actions)))
+        opinion = tuple(opinion_update_heuristic(list(context.actions)))
+        trust = tuple(trust_heuristic(list(context.actions)))
+        summary = {
+            "actor_count": len(context.actors),
+            "content_count": len(context.content),
+            "platform_mix": list(context.platform_mix),
+            "action_counts": event_log.to_summary(),
+            "governance_hooks_available": bool(context.governance_hooks) or context.runtime_mode == RuntimeMode.PRODUCTION,
+            "simulation_disclaimer": "Synthetic deterministic simulation; no live platform access or real PII.",
+        }
+        return SimulationResult(context.scenario, context.runtime_mode, event_log, recommendations, diffusion, opinion, trust, context.provenance_labels, summary)
+
+
+def run_simulation(context: SimulationContext) -> SimulationResult:
+    return DeterministicSimulationRunner().run(context)

--- a/tests/socialsense/test_3c_adapter.py
+++ b/tests/socialsense/test_3c_adapter.py
@@ -1,0 +1,8 @@
+from socialsense_core.adapters.threec_marketing_adapter import simulate_brand_sentiment, simulate_campaign_response, simulate_social_commerce_response
+
+
+def test_3c_adapter_interfaces_exist():
+    result = simulate_campaign_response("campaign", "product", {"name": "aud"}, ["tiktok"])
+    assert result.summary["platform_mix"] == ["tiktok"]
+    assert simulate_brand_sentiment("brand", {}, ["facebook"]).event_log
+    assert simulate_social_commerce_response("offer", "product", {}, ["line"]).event_log

--- a/tests/socialsense/test_action_registry.py
+++ b/tests/socialsense/test_action_registry.py
@@ -1,0 +1,9 @@
+from socialsense_core.actions.registry import get_default_action_registry
+
+
+def test_action_registry_loads_core_actions():
+    registry = get_default_action_registry()
+    assert registry.has("post")
+    assert registry.has("rumor_spread")
+    assert registry.has("purchase_intent")
+    assert "refresh_feed" in registry.actions_for("public_feed")

--- a/tests/socialsense/test_behavior_modules.py
+++ b/tests/socialsense/test_behavior_modules.py
@@ -1,0 +1,8 @@
+from socialsense_core.behaviors.registry import get_default_behavior_registry
+
+
+def test_behavior_modules_expose_expected_actions():
+    registry = get_default_behavior_registry()
+    assert "public_feed" in registry.keys()
+    assert "post" in registry.get("public_feed").actions
+    assert "rumor_spread" in registry.get("crisis_spread").actions

--- a/tests/socialsense/test_civicsense_adapter.py
+++ b/tests/socialsense/test_civicsense_adapter.py
@@ -1,0 +1,8 @@
+from socialsense_core.adapters.civicsense_adapter import simulate_crisis_response, simulate_policy_message_diffusion, simulate_public_opinion
+
+
+def test_civicsense_adapter_interfaces_exist():
+    result = simulate_public_opinion("message", {"name": "aud"}, ["line"], "context")
+    assert result.summary["platform_mix"] == ["line"]
+    assert simulate_crisis_response("crisis", {}, ["facebook"], "ctx").event_log
+    assert simulate_policy_message_diffusion("policy", {}, ["youtube"], "ctx").event_log

--- a/tests/socialsense/test_core_architecture.py
+++ b/tests/socialsense/test_core_architecture.py
@@ -1,0 +1,117 @@
+from dataclasses import is_dataclass
+from enum import Enum
+
+import socialsense_core as core
+from socialsense_core.actions.registry import build_default_action_registry
+from socialsense_core.behaviors.registry import get_default_behavior_registry
+from socialsense_core.platforms.registry import get_default_platform_registry
+
+
+def test_required_core_abstractions_are_public() -> None:
+    required_dataclasses = (
+        core.SocialAction,
+        core.SocialEvent,
+        core.SocialActor,
+        core.SocialContent,
+        core.SocialPlatformPreset,
+        core.SocialBehaviorModule,
+        core.SimulationContext,
+        core.SimulationResult,
+        core.RecommendationSignal,
+        core.DiffusionSignal,
+        core.OpinionSignal,
+        core.TrustSignal,
+    )
+
+    for abstraction in required_dataclasses:
+        assert is_dataclass(abstraction), abstraction
+
+    assert issubclass(core.ProvenanceLabel, Enum)
+    assert issubclass(core.RuntimeMode, Enum)
+
+
+def test_behavior_modules_and_platform_presets_are_data_driven() -> None:
+    behavior_registry = get_default_behavior_registry()
+    platform_registry = get_default_platform_registry()
+    action_registry = build_default_action_registry()
+
+    assert set(behavior_registry.keys()) == {
+        "community_group",
+        "crisis_spread",
+        "information_diffusion",
+        "influencer_network",
+        "long_form_video",
+        "opinion_formation",
+        "private_messaging",
+        "public_feed",
+        "recommendation",
+        "social_commerce",
+        "short_video",
+        "trust_credibility",
+    }
+    assert set(platform_registry.keys()) == {
+        "facebook",
+        "line",
+        "reddit",
+        "tiktok",
+        "x_twitter",
+        "youtube",
+    }
+
+    available_actions = set(action_registry.all_actions())
+    for module in behavior_registry.all():
+        assert module.actions
+        assert set(module.actions).issubset(available_actions)
+
+    available_modules = set(behavior_registry.keys())
+    for preset in platform_registry.all():
+        assert preset.actions
+        assert isinstance(preset.context_notes, tuple)
+        assert set(preset.behavior_modules).issubset(available_modules)
+
+
+def test_simulation_context_result_signals_and_governance_hooks() -> None:
+    actor = core.SocialActor(actor_id="actor-1", display_name="Research actor")
+    content = core.SocialContent(content_id="content-1", text="Synthetic content", author_id="actor-1")
+    post_action = core.SocialAction(
+        action_type="post",
+        actor_id="actor-1",
+        content_id="content-1",
+        platform="x_twitter",
+        payload={"synthetic": True},
+    )
+    react_action = core.SocialAction(
+        action_type="react",
+        actor_id="actor-1",
+        content_id="content-1",
+        platform="x_twitter",
+    )
+    trust_action = core.SocialAction(
+        action_type="evaluate_source_trust",
+        actor_id="actor-1",
+        target_id="source-1",
+        platform="youtube",
+    )
+    context = core.SimulationContext.build(
+        scenario="architecture contract smoke test",
+        actors=[actor],
+        content=[content],
+        platform_mix=["x_twitter"],
+        actions=[post_action, react_action, trust_action],
+        runtime_mode="production",
+        provenance_labels=(core.ProvenanceLabel.SYNTHETIC, core.ProvenanceLabel.HUMAN_AUTHORED_SCENARIO),
+        governance_hooks={"audit": "enabled-by-host"},
+    )
+
+    result = core.run_simulation(context)
+
+    assert context.runtime_mode is core.RuntimeMode.PRODUCTION
+    assert result.runtime_mode is core.RuntimeMode.PRODUCTION
+    assert result.provenance_labels == context.provenance_labels
+    assert result.event_log.to_summary() == {"evaluate_source_trust": 1, "post": 1, "react": 1}
+    assert result.summary["governance_hooks_available"] is True
+    assert result.summary["simulation_disclaimer"] == "Synthetic deterministic simulation; no live platform access or real PII."
+    assert result.recommendation_signals[0].content_id == "content-1"
+    assert result.diffusion_signals[0].content_id == "content-1"
+    assert result.opinion_signals[0].actor_id == "actor-1"
+    assert result.trust_signals[0].actor_id == "actor-1"

--- a/tests/socialsense/test_diffusion_heuristics.py
+++ b/tests/socialsense/test_diffusion_heuristics.py
@@ -1,0 +1,8 @@
+from socialsense_core.actions.types import SocialAction
+from socialsense_core.recommendation.heuristics import diffusion_heuristic
+
+
+def test_diffusion_heuristic_reflects_shares():
+    signals = diffusion_heuristic([SocialAction("post", "a1", "c1"), SocialAction("share", "a1", "c1")])
+    assert signals[0].reach > 1.0
+    assert signals[0].velocity > 0.1

--- a/tests/socialsense/test_event_log.py
+++ b/tests/socialsense/test_event_log.py
@@ -1,0 +1,11 @@
+from socialsense_core.actions.types import SocialAction
+from socialsense_core.events.event_log import EventLog
+from socialsense_core.events.types import SocialEvent
+
+
+def test_event_log_records_actions():
+    log = EventLog()
+    log.append(SocialEvent("evt-1", SocialAction("post", "a1", "c1")))
+    assert len(log) == 1
+    assert log.to_summary() == {"post": 1}
+    assert log.by_action("post")[0].event_id == "evt-1"

--- a/tests/socialsense/test_examples_import.py
+++ b/tests/socialsense/test_examples_import.py
@@ -1,0 +1,10 @@
+import importlib.util
+from pathlib import Path
+
+
+def test_examples_import_successfully():
+    for path in Path("examples").glob("socialsense_*_demo.py"):
+        spec = importlib.util.spec_from_file_location(path.stem, path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        assert hasattr(module, "main")

--- a/tests/socialsense/test_opinion_update.py
+++ b/tests/socialsense/test_opinion_update.py
@@ -1,0 +1,8 @@
+from socialsense_core.actions.types import SocialAction
+from socialsense_core.recommendation.heuristics import opinion_update_heuristic
+
+
+def test_opinion_update_has_actor_delta():
+    signals = opinion_update_heuristic([SocialAction("react", "a1", "c1"), SocialAction("update_belief", "a1", "c1")])
+    assert signals[0].actor_id == "a1"
+    assert signals[0].sentiment_delta > 0

--- a/tests/socialsense/test_platform_presets.py
+++ b/tests/socialsense/test_platform_presets.py
@@ -1,0 +1,10 @@
+from socialsense_core.platforms.registry import get_default_platform_registry
+
+
+def test_platform_presets_map_expected_behavior_modules():
+    registry = get_default_platform_registry()
+    assert "line" in registry.keys()
+    assert "private_messaging" in registry.get("line").behavior_modules
+    assert "short_video" in registry.get("tiktok").behavior_modules
+    assert "community_group" in registry.get("reddit").behavior_modules
+    assert "post" in registry.get("x_twitter").actions

--- a/tests/socialsense/test_recommendation_heuristics.py
+++ b/tests/socialsense/test_recommendation_heuristics.py
@@ -1,0 +1,8 @@
+from socialsense_core.actions.types import SocialAction
+from socialsense_core.recommendation.heuristics import recommendation_heuristic
+
+
+def test_recommendation_heuristic_scores_content():
+    signals = recommendation_heuristic([SocialAction("post", "a1", "c1"), SocialAction("share", "a1", "c1")])
+    assert signals[0].content_id == "c1"
+    assert signals[0].score > 1.0

--- a/tests/socialsense/test_runtime_modes.py
+++ b/tests/socialsense/test_runtime_modes.py
@@ -1,0 +1,12 @@
+from socialsense_core import RuntimeMode, SocialAction, SocialActor, SocialContent
+from socialsense_core.simulation.context import SimulationContext
+from socialsense_core.simulation.runner import run_simulation
+
+
+def test_research_mode_supported_and_production_hooks_exist():
+    research = SimulationContext.build("research", [SocialActor("a", "A")], [SocialContent("c", "C")], ["line"], [SocialAction("post", "a", "c")], runtime_mode="research")
+    prod = SimulationContext.build("prod", [SocialActor("a", "A")], [SocialContent("c", "C")], ["line"], [SocialAction("post", "a", "c")], runtime_mode="production", governance_hooks={"policy": "downstream"})
+    assert research.runtime_mode == RuntimeMode.RESEARCH
+    result = run_simulation(prod)
+    assert result.runtime_mode == RuntimeMode.PRODUCTION
+    assert result.summary["governance_hooks_available"] is True

--- a/tests/socialsense/test_simulation_runner.py
+++ b/tests/socialsense/test_simulation_runner.py
@@ -1,0 +1,18 @@
+from socialsense_core import SocialAction, SocialActor, SocialContent
+from socialsense_core.simulation.context import SimulationContext
+from socialsense_core.simulation.runner import run_simulation
+
+
+def test_simulation_runner_returns_deterministic_results():
+    context = SimulationContext.build(
+        scenario="deterministic",
+        actors=[SocialActor("a1", "Actor")],
+        content=[SocialContent("c1", "Message")],
+        platform_mix=["line"],
+        actions=[SocialAction("post", "a1", "c1"), SocialAction("share", "a1", "c1")],
+    )
+    r1 = run_simulation(context)
+    r2 = run_simulation(context)
+    assert [e.event_id for e in r1.event_log] == ["evt-0001", "evt-0002"]
+    assert r1.summary == r2.summary
+    assert r1.recommendation_signals == r2.recommendation_signals


### PR DESCRIPTION
## Summary

OASIS repository used: https://github.com/camel-ai/oasis

This PR adds **SocialSense Core Foundation**, a reusable, platform-agnostic social media simulation layer derived from OASIS reconnaissance but not coupled to OASIS runtime internals.

## What was added

- `socialsense_core` package with typed dataclass entities, registries, deterministic runner, event log, heuristics, runtime modes, provenance labels, platform presets, and adapter interfaces.
- OASIS reconnaissance and architecture documentation under `docs/socialsense/`.
- Synthetic runnable demos under `examples/socialsense_*_demo.py`.
- Focused test suite under `tests/socialsense/`.
- QA, code review, and safety review reports.
- `pyproject.toml` package inclusion for `socialsense_core`.

## Why SocialSense Core is separate from CivicSense

CivicSense has product-specific policy boundaries, UX, governance, and domain assumptions. SocialSense Core is kept reusable for CivicSense, 3C Marketing Simulator, public opinion research apps, crisis communication simulators, marketing/consumer insight simulators, and future applications. Downstream apps enforce production policies through governance hooks/adapters.

## How OASIS concepts were mapped

OASIS is used as a research base, not a direct product dependency. The PR maps OASIS Twitter/X and Reddit concepts into generic behavior modules:

- OASIS `CREATE_POST` → Public Feed `post` / Reddit Community Group `post_topic`
- `CREATE_COMMENT` → `comment` / `reply`
- `LIKE_POST` and `DISLIKE_POST` → `react` with platform-specific interpretation
- `REPOST` / `QUOTE_POST` → `share`
- `FOLLOW` → `follow`
- `SEARCH_POSTS` / `TREND` / `REFRESH` → discovery/feed actions
- Reddit hot-score concepts inform trust/community/recommendation mappings

See `docs/socialsense/OASIS_RECON_REPORT.md` and `docs/socialsense/OASIS_MAPPING_STRATEGY.md`.

## Supported behavior modules

- Public Feed
- Community Group
- Private Messaging
- Short Video
- Long-form Video
- Influencer Network
- Recommendation / Discovery
- Information Diffusion
- Opinion Formation
- Trust / Credibility
- Social Commerce
- Crisis Spread

## Supported platform presets

Initial presets:

- X / Twitter
- Reddit
- LINE
- Facebook
- TikTok
- YouTube

Thai-first priority is documented in `docs/socialsense/THAI_PLATFORM_PRIORITIES.md`.

## Research Mode vs Production Mode

- **Research Mode** supports broad synthetic modeling of influence propagation, persuasion dynamics, information diffusion, social contagion, opinion formation, recommendation dynamics, marketing response, and crisis response.
- **Production Mode** exists as a runtime marker and governance hook surface. The core intentionally avoids hard-coding CivicSense- or 3C-specific policy restrictions; downstream applications enforce their own boundaries.

## Adapter interfaces

CivicSense adapter:

- `simulate_public_opinion(...)`
- `simulate_crisis_response(...)`
- `simulate_policy_message_diffusion(...)`

3C Marketing adapter:

- `simulate_campaign_response(...)`
- `simulate_brand_sentiment(...)`
- `simulate_social_commerce_response(...)`

## Examples added

- `examples/socialsense_line_group_demo.py`
- `examples/socialsense_facebook_group_demo.py`
- `examples/socialsense_tiktok_short_video_demo.py`
- `examples/socialsense_youtube_video_demo.py`
- `examples/socialsense_thai_platform_mix_demo.py`
- `examples/socialsense_civicsense_adapter_demo.py`
- `examples/socialsense_3c_adapter_demo.py`

All examples use synthetic/mock data only and require no API keys.

## Tests added

Focused tests under `tests/socialsense/` cover:

- Registries load
- Behavior modules expose expected actions
- Platform presets map to expected behavior modules
- Deterministic simulation runner
- Event log behavior
- Recommendation/diffusion/opinion heuristics
- Runtime modes and production hook availability
- CivicSense and 3C adapter interfaces
- Example importability
- Public core architecture/export contract

## QA results

`python3 -m pytest tests/socialsense -q`

Result:

```text
15 passed in 0.02s
```

Example smoke tests executed successfully for all 7 demos.

Broad upstream OASIS tests were not feasible in this local environment because required upstream dependencies such as `camel` and `torch` are missing. This is documented in `docs/socialsense/QA_REPORT.md`.

## Code review summary

`docs/socialsense/CODE_REVIEW.md` verdict: **APPROVED**

Reviewer confirmed modular architecture, platform-agnostic core, separated platform presets, no CivicSense hard dependency, no real credentials/API/scraping usage in SocialSense scope, and clear tests/examples/docs.

## Safety review summary

`docs/socialsense/SAFETY_REVIEW.md` verdict: **APPROVED**

Reviewer confirmed Research Mode labeling, Production Mode hooks, synthetic examples, no real PII requirement, no live platform access, no hidden external calls in SocialSense scope, provenance labels, and simulation disclaimers.

## Known limitations

- The deterministic MVP is a foundation, not an OASIS-scale agent simulation engine.
- Production Mode is a hook/marker only; downstream applications must enforce production policy.
- Upstream OASIS full test suite was not run due to missing/heavy dependencies in the local environment.
- No real platform APIs, platform credentials, scraping, or live data integrations are included.

## Next recommended PRs

1. Optional OASIS trace importer for offline traces.
2. Graph-based diffusion model plugin.
3. Configurable recommendation models with no default external services.
4. Richer Thai platform presets: Instagram, Pantip, Threads, Lemon8.
5. Visualization helpers for executive dashboards and PDFs.
6. Downstream CivicSense integration PR.
7. Downstream 3C Marketing Simulator integration PR.
8. Governance plugin contracts for production deployments.

## Merge policy

Do not merge automatically.
