### PR TITLE
fix(recsys): keep likes when a user has exactly 5 liked posts (off-by-one)

### DIFF
--- a/oasis/social_platform/recsys.py
+++ b/oasis/social_platform/recsys.py
@@ -375,7 +375,7 @@ def get_like_post_id(user_id, action, trace_table):
     recently liked post. Only take IDs, not content, because calculating
     embeddings for all posts again is very time-consuming, especially when the
     number of agents is large"""
-    if len(trace_post_ids) < 5 and len(trace_post_ids) > 0:
+    if len(trace_post_ids) <= 5 and len(trace_post_ids) > 0:
         trace_post_ids += [trace_post_ids[-1]] * (5 - len(trace_post_ids))
     elif len(trace_post_ids) > 5:
         trace_post_ids = trace_post_ids[-5:]

--- a/test/infra/recsys/test_recsys.py
+++ b/test/infra/recsys/test_recsys.py
@@ -11,7 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =========== Copyright 2023 @ CAMEL-AI.org. All Rights Reserved. ===========
-from oasis.social_platform.recsys import (rec_sys_personalized,
+from oasis.social_platform.recsys import (get_like_post_id,
+                                          rec_sys_personalized,
                                           rec_sys_personalized_twh,
                                           rec_sys_random, rec_sys_reddit,
                                           reset_globals)
@@ -39,6 +40,20 @@ def test_rec_sys_reddit_all_posts():
     expected = [["1", "2"], ["1", "2"]]
     result = rec_sys_reddit(post_table, rec_matrix, max_rec_post_len)
     assert result == expected
+
+
+def test_get_like_post_id_exactly_five():
+    # A user with exactly 5 liked posts must get those 5 ids back (last-5,
+    # padded when fewer). Regression: the len==5 boundary previously fell
+    # through to the empty-case placeholder [0], discarding the likes.
+    action = "like_post"
+    trace_table = [{
+        "user_id": 1,
+        "action": action,
+        "info": str({"post_id": pid}),
+    } for pid in [101, 102, 103, 104, 105]]
+
+    assert get_like_post_id(1, action, trace_table) == [101, 102, 103, 104, 105]
 
 
 def test_rec_sys_personalized_all_posts():


### PR DESCRIPTION
## Problem

`get_like_post_id` (`oasis/social_platform/recsys.py`) is documented as *"take the last 5 liked posts, if not enough, pad with the most recently liked post."* But the length branches have an off-by-one gap:

```python
if len(trace_post_ids) < 5 and len(trace_post_ids) > 0:
    trace_post_ids += [trace_post_ids[-1]] * (5 - len(trace_post_ids))   # 1..4: pad
elif len(trace_post_ids) > 5:
    trace_post_ids = trace_post_ids[-5:]                                  # >5: last 5
else:
    trace_post_ids = [0]                                                  # meant for 0
```

`len == 5` matches neither `< 5` nor `> 5`, so it falls into the `else` — which is intended only for the **empty** case — and returns the placeholder `[0]`. A user with **exactly 5** liked posts has all 5 likes discarded.

Downstream, `rec_sys_personalized_twh` (the `enable_like_score=True` path) checks `if len(like_post_ids) != 1:`. Since the buggy result `[0]` has length 1, a user with exactly 5 likes is treated as having **no** likes — their liked-post vectors are replaced by their own profile vector, silently dropping their like-based personalization signal.

## Reproduction

Trace with exactly 5 like actions, post_ids `[101,102,103,104,105]`:

| likes (n) | before | after |
|---|---|---|
| 4 | `[101,102,103,104,104]` | (same) |
| **5** | `[0]` ❌ | `[101,102,103,104,105]` ✅ |
| 6 | `[102,103,104,105,106]` | (same) |

Only `n == 5` was broken; 0, 1–4, and >5 are unchanged.

## Fix

Change the first condition from `< 5` to `<= 5` (the pad expression `[...] * (5 - 5)` adds nothing at n=5):

```python
if len(trace_post_ids) <= 5 and len(trace_post_ids) > 0:
```

## Test

Added `test_get_like_post_id_exactly_five` to `test/infra/recsys/test_recsys.py`, asserting a 5-like trace returns the 5 ids (not `[0]`). It fails on the current code and passes after the fix.

I verified the fix RED→GREEN on the pure function directly (it only uses `ast.literal_eval` + list ops). I couldn't run the full `test_recsys.py` locally because importing `oasis.social_platform.recsys` pulls torch / sentence-transformers and this environment has a `huggingface-hub` version conflict — CI should run it cleanly.
