### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ If you're keen on exploring new research opportunities or discoveries with our p
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=camel-ai/oasis&type=Date)](https://star-history.com/#camel-ai/oasis&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=camel-ai/oasis&type=Date)](https://star-history.dera.page/#camel-ai/oasis&type=date)
 
 ## 🔗 Citation
 


### PR DESCRIPTION
The star history chart in the README has been broken for a while and no longer displays. Since a working star history chart is important for showcasing the project's growth, this PR updates it to a working service so it renders correctly again. No other files are changed.